### PR TITLE
DM-51844: Avoid setting null values in technote.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 <!-- scriv-insert-here -->
 
+<a id='changelog-2.1.1'></a>
+## 2.1.1 (2025-07-17)
+
+### Bug fixes
+
+- When adding or updating authors in `technote.toml`, Documenteer avoids setting null values. TOML represents null values as absent keys, but previous versions of Documenteer included null `ror` values.
+
 <a id='changelog-2.1.0'></a>
 ## 2.1.0 (2025-07-16)
 

--- a/src/documenteer/storage/technotetoml.py
+++ b/src/documenteer/storage/technotetoml.py
@@ -105,17 +105,26 @@ class TechnoteTomlFile:
     ) -> None:
         """Update a toml author table with the Author data."""
         name_table = tomlkit.inline_table()
-        name_table["given"] = author.given_name
-        name_table["family"] = author.family_name
+        if author.given_name is not None:
+            name_table["given"] = author.given_name
+        if author.family_name is not None:
+            name_table["family"] = author.family_name
+
         table["name"] = name_table
+
         table["internal_id"] = author.internal_id
+
         if author.orcid is not None:
             table["orcid"] = str(author.orcid)
 
         if "affiliations" not in table:
             table.add("affiliations", tomlkit.aot())
         affiliations_aot = cast(tomlkit.items.AoT, table["affiliations"])
-        existing_affiliation_ids = [a["internal_id"] for a in affiliations_aot]
+
+        existing_affiliation_ids = [
+            a["internal_id"] for a in affiliations_aot if "internal_id" in a
+        ]
+
         for affiliation in author.affiliations:
             if affiliation.internal_id not in existing_affiliation_ids:
                 # Add a new affiliation
@@ -134,4 +143,5 @@ class TechnoteTomlFile:
     ) -> None:
         t["name"] = affiliation_info.name
         t["internal_id"] = affiliation_info.internal_id
-        t["ror"] = str(affiliation_info.ror)
+        if affiliation_info.ror is not None:
+            t["ror"] = str(affiliation_info.ror)

--- a/tests/storage/technotetoml_test.py
+++ b/tests/storage/technotetoml_test.py
@@ -6,6 +6,7 @@ from typing import cast
 
 import pytest_responses  # noqa: F401
 import tomlkit
+import tomlkit.items
 from responses import RequestsMock
 
 from documenteer.storage.authordb import AuthorDb
@@ -123,3 +124,213 @@ def test_append_author(responses: RequestsMock) -> None:
     technote.upsert_author(author2)
     name = cast("tomlkit.items.Table", authors_aot[1]["name"])
     assert cast("str", name["given"]) == "Frossie"
+
+
+def test_author_with_null_orcid(responses: RequestsMock) -> None:
+    """Test handling of author with null ORCID."""
+    author_response_data = """
+{
+    "affiliations": [
+        {
+            "address": {
+                "city": "Tucson",
+                "country": "USA",
+                "postal_code": "85719",
+                "state": "AZ",
+                "street": "950 N. Cherry Ave."
+            },
+            "department": null,
+            "internal_id": "RubinObs",
+            "name": "Vera C. Rubin Observatory Project Office",
+            "ror": "https://ror.org/048g3cy84"
+        }
+    ],
+    "family_name": "Smith",
+    "given_name": "John",
+    "internal_id": "smithj",
+    "notes": [],
+    "orcid": null
+}
+"""
+    responses.get(
+        "https://roundtable.lsst.cloud/ook/authors/smithj",
+        body=author_response_data,
+        content_type="application/json",
+        status=200,
+    )
+
+    author_db = AuthorDb()
+    author = author_db.get_author("smithj")
+
+    technote = TechnoteTomlFile(BASIC_TECHNOTE_TOML)
+    technote.upsert_author(author)
+
+    authors_aot = technote.authors_aot
+    a = authors_aot[0]
+    name = cast("tomlkit.items.Table", a["name"])
+    assert cast("str", name["given"]) == "John"
+    assert cast("str", name["family"]) == "Smith"
+    assert cast("str", a["internal_id"]) == "smithj"
+    # ORCID should not be present in the TOML when it's null
+    assert "orcid" not in a
+
+
+def test_author_with_null_given_name(responses: RequestsMock) -> None:
+    """Test handling of author with null given name."""
+    author_response_data = """
+{
+    "affiliations": [
+        {
+            "address": {
+                "city": "Cambridge",
+                "country": "USA",
+                "postal_code": "02138",
+                "state": "MA",
+                "street": "1 Harvard Yard"
+            },
+            "department": null,
+            "internal_id": "Harvard",
+            "name": "Harvard University",
+            "ror": "https://ror.org/03vek6s52"
+        }
+    ],
+    "family_name": "Lastname",
+    "given_name": null,
+    "internal_id": "lastnamex",
+    "notes": [],
+    "orcid": "https://orcid.org/0000-0000-0000-0000"
+}
+"""
+    responses.get(
+        "https://roundtable.lsst.cloud/ook/authors/lastnamex",
+        body=author_response_data,
+        content_type="application/json",
+        status=200,
+    )
+
+    author_db = AuthorDb()
+    author = author_db.get_author("lastnamex")
+
+    technote = TechnoteTomlFile(BASIC_TECHNOTE_TOML)
+    technote.upsert_author(author)
+
+    authors_aot = technote.authors_aot
+    a = authors_aot[0]
+    name = cast("tomlkit.items.Table", a["name"])
+    # Given name should not be present in the TOML when it's null
+    assert "given" not in name
+    assert cast("str", name["family"]) == "Lastname"
+    assert cast("str", a["internal_id"]) == "lastnamex"
+    assert cast("str", a["orcid"]) == "https://orcid.org/0000-0000-0000-0000"
+
+
+def test_author_with_affiliation_null_ror(responses: RequestsMock) -> None:
+    """Test handling of affiliation with null ROR."""
+    author_response_data = """
+{
+    "affiliations": [
+        {
+            "address": {
+                "city": "Small Town",
+                "country": "USA",
+                "postal_code": "12345",
+                "state": "ST",
+                "street": "123 Main St"
+            },
+            "department": "Engineering",
+            "internal_id": "SmallOrg",
+            "name": "Small Organization Inc.",
+            "ror": null
+        }
+    ],
+    "family_name": "Doe",
+    "given_name": "Jane",
+    "internal_id": "doej",
+    "notes": [],
+    "orcid": "https://orcid.org/0000-0000-0000-0001"
+}
+"""
+    responses.get(
+        "https://roundtable.lsst.cloud/ook/authors/doej",
+        body=author_response_data,
+        content_type="application/json",
+        status=200,
+    )
+
+    author_db = AuthorDb()
+    author = author_db.get_author("doej")
+
+    technote = TechnoteTomlFile(BASIC_TECHNOTE_TOML)
+    technote.upsert_author(author)
+
+    authors_aot = technote.authors_aot
+    a = authors_aot[0]
+    name = cast("tomlkit.items.Table", a["name"])
+    assert cast("str", name["given"]) == "Jane"
+    assert cast("str", name["family"]) == "Doe"
+    assert cast("str", a["internal_id"]) == "doej"
+    assert cast("str", a["orcid"]) == "https://orcid.org/0000-0000-0000-0001"
+
+    affiliations_aot = cast("tomlkit.items.AoT", a["affiliations"])
+    affiliation = affiliations_aot[0]
+    assert cast("str", affiliation["name"]) == "Small Organization Inc."
+    assert cast("str", affiliation["internal_id"]) == "SmallOrg"
+    # ROR should not be present in the TOML when it's null
+    assert "ror" not in affiliation
+
+
+def test_author_with_multiple_null_fields(responses: RequestsMock) -> None:
+    """Test handling of author with multiple null fields."""
+    author_response_data = """
+{
+    "affiliations": [
+        {
+            "address": {
+                "city": "Unknown City",
+                "country": "Unknown Country",
+                "postal_code": null,
+                "state": null,
+                "street": null
+            },
+            "department": null,
+            "internal_id": "UnknownOrg",
+            "name": "Unknown Organization",
+            "ror": null
+        }
+    ],
+    "family_name": "Anonymous",
+    "given_name": null,
+    "internal_id": "anon",
+    "notes": [],
+    "orcid": null
+}
+"""
+    responses.get(
+        "https://roundtable.lsst.cloud/ook/authors/anon",
+        body=author_response_data,
+        content_type="application/json",
+        status=200,
+    )
+
+    author_db = AuthorDb()
+    author = author_db.get_author("anon")
+
+    technote = TechnoteTomlFile(BASIC_TECHNOTE_TOML)
+    technote.upsert_author(author)
+
+    authors_aot = technote.authors_aot
+    a = authors_aot[0]
+    name = cast("tomlkit.items.Table", a["name"])
+    # Given name should not be present when null
+    assert "given" not in name
+    assert cast("str", name["family"]) == "Anonymous"
+    assert cast("str", a["internal_id"]) == "anon"
+    # ORCID should not be present when null
+    assert "orcid" not in a
+
+    affiliations_aot = cast("tomlkit.items.AoT", a["affiliations"])
+    affiliation = affiliations_aot[0]
+    assert cast("str", affiliation["name"]) == "Unknown Organization"
+    assert cast("str", affiliation["internal_id"]) == "UnknownOrg"
+    # ROR should not be present when null
+    assert "ror" not in affiliation


### PR DESCRIPTION
TOML represents null values through absent keys, but we were accidentally setting a null ror as "None" by way of attempting to stringify the HttpUrl from Pydantic.

We now test for null orcid, ror, and given_name.

Release as Documenteer 2.1.1.