### PR TITLE
DM-53811: Add "Last updated" footer from Git timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 <!-- scriv-insert-here -->
 
+<a id='changelog-2.4.0'></a>
+## 2.4.0 (2026-06-17)
+
+### New features
+
+- User guide pages now show a "This page was last modified on <date>." timestamp at the bottom of each page, derived from the page's Git commit history. The date is the most recent commit across the page's own source file and any files it pulls in via `include`/`literalinclude`, so editing an included snippet updates every page that uses it. This is on by default and can be disabled with `show_last_updated = false` in the `[sphinx.theme]` table of `documenteer.toml`.
+
+  The footer date is rendered as a `<time>` element whose `datetime` attribute carries the canonical UTC ISO 8601 timestamp, and a small bundled script (`rubin-last-modified.js`) rewrites the visible text to the reader's own local date (for example "June 1, 2024"). With JavaScript disabled the element falls back to the UTC date as `YYYY-MM-DD`. This ensures readers in any timezone see the correct calendar day, which a fixed UTC date can otherwise misrepresent.
+
+  The extension is also the single source of truth for the page's last-modified date in the HTML `<head>`: it emits the same Git date as an `article:modified_time` (Open Graph), `dcterms.modified` (Dublin Core), and a Schema.org `dateModified` (JSON-LD). The user-guide preset sets `git_last_updated_metatags = false` so the auto-loaded `sphinx-last-updated-by-git` extension (still used for the sitemap) doesn't emit a duplicate Open Graph tag from a separate Git computation.
+
+  Because the date comes from Git, CI builds must check out the full history (set `fetch-depth: 0` with `actions/checkout`). To avoid publishing misleading dates, Documenteer detects a shallow clone, omits the timestamp from every page, and emits a build warning.
+
+### Other changes
+
+- Fixed pytest configuration in `pyproject.toml` by consolidating conflicting `[tool.pytest]` and `[tool.pytest.ini_options]` sections into a single `[tool.pytest.ini_options]` section. This resolves an error that prevented tests from running.
+
 <a id='changelog-2.3.0'></a>
 ## 2.3.0 (2025-09-03)
 

--- a/changelog.d/20251110_pytest_config.md
+++ b/changelog.d/20251110_pytest_config.md
@@ -1,3 +1,0 @@
-### Other changes
-
-- Fixed pytest configuration in `pyproject.toml` by consolidating conflicting `[tool.pytest]` and `[tool.pytest.ini_options]` sections into a single `[tool.pytest.ini_options]` section. This resolves an error that prevented tests from running.

--- a/changelog.d/20260615_last_modified.md
+++ b/changelog.d/20260615_last_modified.md
@@ -1,9 +1,0 @@
-### New features
-
-- User guide pages now show a "This page was last modified on <date>." timestamp at the bottom of each page, derived from the page's Git commit history. The date is the most recent commit across the page's own source file and any files it pulls in via `include`/`literalinclude`, so editing an included snippet updates every page that uses it. This is on by default and can be disabled with `show_last_updated = false` in the `[sphinx.theme]` table of `documenteer.toml`.
-
-  The footer date is rendered as a `<time>` element whose `datetime` attribute carries the canonical UTC ISO 8601 timestamp, and a small bundled script (`rubin-last-modified.js`) rewrites the visible text to the reader's own local date (for example "June 1, 2024"). With JavaScript disabled the element falls back to the UTC date as `YYYY-MM-DD`. This ensures readers in any timezone see the correct calendar day, which a fixed UTC date can otherwise misrepresent.
-
-  The extension is also the single source of truth for the page's last-modified date in the HTML `<head>`: it emits the same Git date as an `article:modified_time` (Open Graph), `dcterms.modified` (Dublin Core), and a Schema.org `dateModified` (JSON-LD). The user-guide preset sets `git_last_updated_metatags = false` so the auto-loaded `sphinx-last-updated-by-git` extension (still used for the sitemap) doesn't emit a duplicate Open Graph tag from a separate Git computation.
-
-  Because the date comes from Git, CI builds must check out the full history (set `fetch-depth: 0` with `actions/checkout`). To avoid publishing misleading dates, Documenteer detects a shallow clone, omits the timestamp from every page, and emits a build warning.

--- a/changelog.d/20260615_last_modified.md
+++ b/changelog.d/20260615_last_modified.md
@@ -1,0 +1,5 @@
+### New features
+
+- User guide pages now show a "Last updated on <date>." timestamp in the footer, derived from the page's Git commit history. The date is the most recent commit across the page's own source file and any files it pulls in via `include`/`literalinclude`, so editing an included snippet updates every page that uses it. This is on by default and can be disabled with `show_last_updated = false` in the `[sphinx.theme]` table of `documenteer.toml`.
+
+  Because the date comes from Git, CI builds must check out the full history (set `fetch-depth: 0` with `actions/checkout`). To avoid publishing misleading dates, Documenteer detects a shallow clone, omits the timestamp from every page, and emits a build warning.

--- a/changelog.d/20260615_last_modified.md
+++ b/changelog.d/20260615_last_modified.md
@@ -1,5 +1,5 @@
 ### New features
 
-- User guide pages now show a "Last updated on <date>." timestamp in the footer, derived from the page's Git commit history. The date is the most recent commit across the page's own source file and any files it pulls in via `include`/`literalinclude`, so editing an included snippet updates every page that uses it. This is on by default and can be disabled with `show_last_updated = false` in the `[sphinx.theme]` table of `documenteer.toml`.
+- User guide pages now show a "Last updated on <date>." timestamp at the bottom of each page, derived from the page's Git commit history. The date is the most recent commit across the page's own source file and any files it pulls in via `include`/`literalinclude`, so editing an included snippet updates every page that uses it. This is on by default and can be disabled with `show_last_updated = false` in the `[sphinx.theme]` table of `documenteer.toml`.
 
   Because the date comes from Git, CI builds must check out the full history (set `fetch-depth: 0` with `actions/checkout`). To avoid publishing misleading dates, Documenteer detects a shallow clone, omits the timestamp from every page, and emits a build warning.

--- a/changelog.d/20260615_last_modified.md
+++ b/changelog.d/20260615_last_modified.md
@@ -1,6 +1,8 @@
 ### New features
 
-- User guide pages now show a "Last updated on <date>." timestamp at the bottom of each page, derived from the page's Git commit history. The date is the most recent commit across the page's own source file and any files it pulls in via `include`/`literalinclude`, so editing an included snippet updates every page that uses it. This is on by default and can be disabled with `show_last_updated = false` in the `[sphinx.theme]` table of `documenteer.toml`.
+- User guide pages now show a "This page was last modified on <date>." timestamp at the bottom of each page, derived from the page's Git commit history. The date is the most recent commit across the page's own source file and any files it pulls in via `include`/`literalinclude`, so editing an included snippet updates every page that uses it. This is on by default and can be disabled with `show_last_updated = false` in the `[sphinx.theme]` table of `documenteer.toml`.
+
+  The footer date is rendered as a `<time>` element whose `datetime` attribute carries the canonical UTC ISO 8601 timestamp, and a small bundled script (`rubin-last-modified.js`) rewrites the visible text to the reader's own local date (for example "June 1, 2024"). With JavaScript disabled the element falls back to the UTC date as `YYYY-MM-DD`. This ensures readers in any timezone see the correct calendar day, which a fixed UTC date can otherwise misrepresent.
 
   The extension is also the single source of truth for the page's last-modified date in the HTML `<head>`: it emits the same Git date as an `article:modified_time` (Open Graph), `dcterms.modified` (Dublin Core), and a Schema.org `dateModified` (JSON-LD). The user-guide preset sets `git_last_updated_metatags = false` so the auto-loaded `sphinx-last-updated-by-git` extension (still used for the sitemap) doesn't emit a duplicate Open Graph tag from a separate Git computation.
 

--- a/changelog.d/20260615_last_modified.md
+++ b/changelog.d/20260615_last_modified.md
@@ -2,4 +2,6 @@
 
 - User guide pages now show a "Last updated on <date>." timestamp at the bottom of each page, derived from the page's Git commit history. The date is the most recent commit across the page's own source file and any files it pulls in via `include`/`literalinclude`, so editing an included snippet updates every page that uses it. This is on by default and can be disabled with `show_last_updated = false` in the `[sphinx.theme]` table of `documenteer.toml`.
 
+  The extension is also the single source of truth for the page's last-modified date in the HTML `<head>`: it emits the same Git date as an `article:modified_time` (Open Graph), `dcterms.modified` (Dublin Core), and a Schema.org `dateModified` (JSON-LD). The user-guide preset sets `git_last_updated_metatags = false` so the auto-loaded `sphinx-last-updated-by-git` extension (still used for the sitemap) doesn't emit a duplicate Open Graph tag from a separate Git computation.
+
   Because the date comes from Git, CI builds must check out the full history (set `fetch-depth: 0` with `actions/checkout`). To avoid publishing misleading dates, Documenteer detects a shallow clone, omits the timestamp from every page, and emits a build warning.

--- a/docs/dev/api/documenteer.ext.rst
+++ b/docs/dev/api/documenteer.ext.rst
@@ -11,6 +11,9 @@ documenteer.ext
 .. automodapi:: documenteer.ext.jira
    :no-inheritance-diagram:
 
+.. automodapi:: documenteer.ext.lastmodified
+   :no-inheritance-diagram:
+
 .. automodapi:: documenteer.ext.lsstdocushare
    :no-inheritance-diagram:
 

--- a/docs/documenteer.toml
+++ b/docs/documenteer.toml
@@ -47,6 +47,9 @@ ignore = [
     "https://mermaid-js.github.io",
     "https://rubin-obs.slack.com",
     "https://slack.com/app_redirect",
+    # github.dev redirects to the vscode.dev SPA, which doesn't finish
+    # loading within linkcheck's timeout and reports a false-positive timeout.
+    "https://github.dev",
 ]
 
 [sphinx.redirects]

--- a/docs/guides/toml-reference.rst
+++ b/docs/guides/toml-reference.rst
@@ -433,13 +433,13 @@ show_last_updated
 
 |optional|
 
-Default is ``true``, so that each page shows a "Last updated on <date>." timestamp in its footer.
+Default is ``true``, so that each page shows a "Last updated on <date>." timestamp at the bottom of each page.
 
 The date is computed from the page's **Git commit history**, not the filesystem modification time (which is meaningless in CI).
 It is the most recent commit date across the page's own source file *and* any files the page pulls in with ``include`` or ``literalinclude`` directives, so editing an included snippet updates every page that uses it.
 Because the date is the last *commit* date, uncommitted local edits don't change it; a page whose source has never been committed shows no timestamp.
 
-Set this to ``false`` to hide the footer timestamp:
+Set this to ``false`` to hide the timestamp:
 
 .. code-block:: toml
    :caption: documenteer.toml

--- a/docs/guides/toml-reference.rst
+++ b/docs/guides/toml-reference.rst
@@ -426,6 +426,42 @@ This configuration requires information about the GitHub repository from these o
 - :ref:`project.github_url <guide-project-github-url>`
 - :ref:`project.github_default_branch <guide-project-github-default-branch>`
 
+.. _guide-project-show-last-updated:
+
+show_last_updated
+-----------------
+
+|optional|
+
+Default is ``true``, so that each page shows a "Last updated on <date>." timestamp in its footer.
+
+The date is computed from the page's **Git commit history**, not the filesystem modification time (which is meaningless in CI).
+It is the most recent commit date across the page's own source file *and* any files the page pulls in with ``include`` or ``literalinclude`` directives, so editing an included snippet updates every page that uses it.
+Because the date is the last *commit* date, uncommitted local edits don't change it; a page whose source has never been committed shows no timestamp.
+
+Set this to ``false`` to hide the footer timestamp:
+
+.. code-block:: toml
+   :caption: documenteer.toml
+
+   [sphinx.theme]
+   show_last_updated = false
+
+.. important::
+
+   Because the date comes from the Git history, your CI build must check out the **full** commit history.
+   With `actions/checkout <https://github.com/actions/checkout>`__, set ``fetch-depth: 0``:
+
+   .. code-block:: yaml
+      :caption: .github/workflows/ci.yaml
+
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+   A shallow clone (the default) only fetches the most recent commit, so every page would otherwise report the same, incorrect date.
+   To avoid publishing misleading data, Documenteer detects a shallow clone, **omits the "Last updated" timestamp from every page**, and emits a single build warning telling you to set ``fetch-depth: 0``.
+
 [sphinx.intersphinx]
 ====================
 

--- a/docs/guides/toml-reference.rst
+++ b/docs/guides/toml-reference.rst
@@ -435,6 +435,11 @@ show_last_updated
 
 Default is ``true``, so that each page shows a "Last updated on <date>." timestamp at the bottom of each page.
 
+.. seealso::
+
+   :doc:`/sphinx-extensions/last-updated` for how the date is computed and the extension's
+   Sphinx configuration values.
+
 The date is computed from the page's **Git commit history**, not the filesystem modification time (which is meaningless in CI).
 It is the most recent commit date across the page's own source file *and* any files the page pulls in with ``include`` or ``literalinclude`` directives, so editing an included snippet updates every page that uses it.
 Because the date is the last *commit* date, uncommitted local edits don't change it; a page whose source has never been committed shows no timestamp.

--- a/docs/sphinx-extensions/index.rst
+++ b/docs/sphinx-extensions/index.rst
@@ -19,3 +19,10 @@ Sphinx extensions
 
    remote-code-block
    openapi
+
+.. toctree::
+   :maxdepth: 2
+   :titlesonly:
+   :caption: Page metadata
+
+   last-updated

--- a/docs/sphinx-extensions/last-updated.rst
+++ b/docs/sphinx-extensions/last-updated.rst
@@ -1,0 +1,93 @@
+.. _documenteer-ext-lastmodified:
+
+##############################
+"Last updated" page timestamps
+##############################
+
+Documenteer's ``documenteer.ext.lastmodified`` extension adds a "Last updated on <date>." timestamp to the bottom of each page's article body.
+The date is derived from the page's **Git commit history** rather than the filesystem modification time, which is meaningless in CI where checkouts have arbitrary timestamps.
+The extension is theme-agnostic: it stores the formatted date in each page's ``last_updated`` template context variable, which pydata-sphinx-theme renders through its built-in ``last-updated`` component.
+
+.. tip::
+
+   If you use Documenteer's user-guide configuration preset, this extension is already enabled and the timestamp is shown by default.
+   Toggle it with the :ref:`show_last_updated <guide-project-show-last-updated>` setting in :file:`documenteer.toml`; you don't need to edit :file:`conf.py`.
+
+How the date is computed
+========================
+
+The timestamp is the most recent commit date across the page's own source file *and* any files it pulls in with the ``include`` or ``literalinclude`` directives.
+Editing an included snippet therefore updates the timestamp on every page that uses it.
+
+Because the date is the last *commit* date:
+
+- Uncommitted local edits don't change it.
+- A page whose source has never been committed shows no timestamp.
+- Generated pages without a source document (such as the search page and general index) show no timestamp.
+
+Full Git history is required
+============================
+
+The date comes from Git, so the build must have the **full** commit history.
+
+.. important::
+
+   With `actions/checkout <https://github.com/actions/checkout>`__, set ``fetch-depth: 0``:
+
+   .. code-block:: yaml
+      :caption: .github/workflows/ci.yaml
+
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+   A shallow clone (the default) only fetches the most recent commit, so every page would otherwise report the same, incorrect date.
+   To avoid publishing misleading data, Documenteer detects a shallow clone, omits the timestamp from every page, and emits a single build warning.
+
+Reference
+=========
+
+Extension module
+----------------
+
+The user-guide configuration preset enables this extension automatically.
+To use it in a standalone Sphinx project, add ``"documenteer.ext.lastmodified"`` to the extensions list in :file:`conf.py` and render the ``last_updated`` context value.
+With pydata-sphinx-theme, add the ``last-updated`` component to the article footer:
+
+.. code-block:: python
+   :caption: conf.py
+
+   extensions = ["documenteer.ext.lastmodified", ...]
+
+   html_theme = "pydata_sphinx_theme"
+   html_theme_options = {
+       "article_footer_items": ["last-updated"],
+   }
+
+Configurations
+--------------
+
+Set these configurations in the Sphinx :file:`conf.py` file.
+
+.. _documenteer-last-modified-enabled-conf:
+
+documenteer\_last\_modified\_enabled
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Whether to compute and show the "Last updated" timestamp.
+A boolean that defaults to `True`.
+In the user-guide preset this is set automatically from the :ref:`show_last_updated <guide-project-show-last-updated>` field in :file:`documenteer.toml`.
+
+.. _documenteer-last-modified-date-format-conf:
+
+documenteer\_last\_modified\_date\_format
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``strftime``-style format string for the date.
+Defaults to ``"%b %d, %Y"`` (for example, ``Jun 16, 2026``).
+The date is formatted with Sphinx's date machinery, so it respects the build's ``language`` setting.
+
+.. code-block:: python
+   :caption: conf.py
+
+   documenteer_last_modified_date_format = "%Y-%m-%d"

--- a/docs/sphinx-extensions/last-updated.rst
+++ b/docs/sphinx-extensions/last-updated.rst
@@ -7,6 +7,7 @@
 Documenteer's ``documenteer.ext.lastmodified`` extension adds a "Last updated on <date>." timestamp to the bottom of each page's article body.
 The date is derived from the page's **Git commit history** rather than the filesystem modification time, which is meaningless in CI where checkouts have arbitrary timestamps.
 The extension is theme-agnostic: it stores the formatted date in each page's ``last_updated`` template context variable, which pydata-sphinx-theme renders through its built-in ``last-updated`` component.
+It is also the single source of truth for the page's last-modified date in the HTML ``<head>``, where it emits the same Git date as Open Graph, Dublin Core, and Schema.org metadata (see `HTML metadata`_).
 
 .. tip::
 
@@ -24,6 +25,23 @@ Because the date is the last *commit* date:
 - Uncommitted local edits don't change it.
 - A page whose source has never been committed shows no timestamp.
 - Generated pages without a source document (such as the search page and general index) show no timestamp.
+
+HTML metadata
+=============
+
+Besides the visible footer timestamp, the extension writes the **same Git commit date** into the page's HTML ``<head>`` as three machine-readable signals, so that downstream consumers all agree:
+
+- ``<meta property="article:modified_time">`` — the `Open Graph <https://ogp.me/>`__ property used by social-media link previews.
+- ``<meta name="dcterms.modified">`` — the `Dublin Core <https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/modified>`__ modification date.
+- A `Schema.org <https://schema.org/dateModified>`__ ``dateModified`` field inside a JSON-LD ``<script type="application/ld+json">`` block (typed as ``WebPage``).
+
+In addition, pydata-sphinx-theme renders a ``<meta name="docbuild:last-update">`` tag from the same ``last_updated`` context value.
+
+.. note::
+
+   sphinx-sitemap (enabled by the user-guide preset) auto-loads `sphinx-last-updated-by-git <https://github.com/mgeier/sphinx-last-updated-by-git>`__ to populate the sitemap's ``<lastmod>`` entries.
+   That extension runs its *own* Git computation and would otherwise emit a second, potentially divergent ``article:modified_time`` tag.
+   To keep this extension the single source of truth, the user-guide preset sets ``git_last_updated_metatags = False``, which silences the duplicate Open Graph tag while leaving the sitemap behavior intact.
 
 Full Git history is required
 ============================

--- a/docs/sphinx-extensions/last-updated.rst
+++ b/docs/sphinx-extensions/last-updated.rst
@@ -32,7 +32,7 @@ HTML metadata
 Besides the visible footer timestamp, the extension writes the **same Git commit date** into the page's HTML ``<head>`` as three machine-readable signals, so that downstream consumers all agree:
 
 - ``<meta property="article:modified_time">`` — the `Open Graph <https://ogp.me/>`__ property used by social-media link previews.
-- ``<meta name="dcterms.modified">`` — the `Dublin Core <https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/modified>`__ modification date.
+- ``<meta name="dcterms.modified">`` — the `Dublin Core <https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#modified>`__ modification date.
 - A `Schema.org <https://schema.org/dateModified>`__ ``dateModified`` field inside a JSON-LD ``<script type="application/ld+json">`` block (typed as ``WebPage``).
 
 In addition, pydata-sphinx-theme renders a ``<meta name="docbuild:last-update">`` tag from the same ``last_updated`` context value.

--- a/docs/sphinx-extensions/last-updated.rst
+++ b/docs/sphinx-extensions/last-updated.rst
@@ -4,10 +4,30 @@
 "Last updated" page timestamps
 ##############################
 
-Documenteer's ``documenteer.ext.lastmodified`` extension adds a "Last updated on <date>." timestamp to the bottom of each page's article body.
+Documenteer's ``documenteer.ext.lastmodified`` extension adds a "This page was last modified on <date>." timestamp to the bottom of each page's article body.
 The date is derived from the page's **Git commit history** rather than the filesystem modification time, which is meaningless in CI where checkouts have arbitrary timestamps.
-The extension is theme-agnostic: it stores the formatted date in each page's ``last_updated`` template context variable, which pydata-sphinx-theme renders through its built-in ``last-updated`` component.
+In the user-guide preset the footer date is rendered to the **reader's** local timezone (see `Reader-localized footer date`_).
 It is also the single source of truth for the page's last-modified date in the HTML ``<head>``, where it emits the same Git date as Open Graph, Dublin Core, and Schema.org metadata (see `HTML metadata`_).
+
+The extension exposes the date to the page template in three forms:
+
+- ``last_updated`` — the date formatted with :ref:`documenteer_last_modified_date_format <documenteer-last-modified-date-format-conf>` in the commit's own timezone offset. Sphinx emits this as the ``docbuild:last-update`` meta tag, and it is the value any theme-agnostic ``last-updated`` rendering uses.
+- ``documenteer_last_modified_iso`` — the canonical UTC ISO 8601 timestamp (for example ``2024-06-01T00:00:00+00:00``).
+- ``documenteer_last_modified_date`` — the UTC date as ``YYYY-MM-DD`` (for example ``2024-06-01``).
+
+Reader-localized footer date
+============================
+
+In the user-guide preset, Documenteer overrides pydata-sphinx-theme's ``last-updated`` component to render the footer date as a ``<time>`` element:
+
+.. code-block:: html
+
+   <time datetime="2024-06-01T00:00:00+00:00">2024-06-01</time>
+
+The ``datetime`` attribute carries the canonical UTC ISO 8601 timestamp, and the visible text is the UTC date as ``YYYY-MM-DD``.
+A small bundled script (``rubin-last-modified.js``) then rewrites the visible text to the **reader's** local date in a long-month style, for example "June 1, 2024".
+This matters because a UTC date can fall on a different calendar day than the reader's local date; localizing in the browser shows each reader the correct day.
+With JavaScript disabled the element keeps its ``YYYY-MM-DD`` UTC fallback text.
 
 .. tip::
 
@@ -104,9 +124,12 @@ In the user-guide preset this is set automatically from the :ref:`show_last_upda
 documenteer\_last\_modified\_date\_format
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The ``strftime``-style format string for the date.
+The ``strftime``-style format string for the ``last_updated`` value.
 Defaults to ``"%b %d, %Y"`` (for example, ``Jun 16, 2026``).
 The date is formatted with Sphinx's date machinery, so it respects the build's ``language`` setting.
+
+This format governs the ``last_updated`` context value — the ``docbuild:last-update`` meta tag and any theme-agnostic ``last-updated`` rendering — **not** the visible footer date in the user-guide preset.
+That footer date is rendered from the UTC ISO timestamp and localized to the reader's timezone by JavaScript (see `Reader-localized footer date`_), so it is not affected by this setting.
 
 .. code-block:: python
    :caption: conf.py

--- a/docs/sphinx-extensions/last-updated.rst
+++ b/docs/sphinx-extensions/last-updated.rst
@@ -35,6 +35,9 @@ Besides the visible footer timestamp, the extension writes the **same Git commit
 - ``<meta name="dcterms.modified">`` — the `Dublin Core <https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#modified>`__ modification date.
 - A `Schema.org <https://schema.org/dateModified>`__ ``dateModified`` field inside a JSON-LD ``<script type="application/ld+json">`` block (typed as ``WebPage``).
 
+These three head signals are expressed in **UTC** (ISO 8601, ``+00:00``), so the metadata is identical regardless of the committer's timezone — a locally-authored commit and its UTC-recorded squash-merge produce the same value.
+The visible footer date, by contrast, reflects the commit's own offset.
+
 In addition, pydata-sphinx-theme renders a ``<meta name="docbuild:last-update">`` tag from the same ``last_updated`` context value.
 
 .. note::

--- a/src/documenteer/assets/rubin-last-modified.js
+++ b/src/documenteer/assets/rubin-last-modified.js
@@ -1,0 +1,45 @@
+// Localize documenteer.ext.lastmodified's "last modified" footer date.
+//
+// The footer renders the page's Git commit date as a <time> element whose
+// datetime attribute carries the canonical UTC ISO 8601 timestamp and whose
+// visible text is the UTC date (YYYY-MM-DD) as a no-JavaScript fallback. This
+// script rewrites that text to the reader's own local date in a long-month
+// style (for example "June 1, 2024"), so a UTC date that lands on a different
+// calendar day than the reader's is shown correctly for the reader.
+//
+// On any parse failure or invalid date the UTC fallback text is left intact.
+(function () {
+  'use strict';
+
+  function localize() {
+    var elements = document.querySelectorAll(
+      'time[data-documenteer-last-modified]'
+    );
+    for (var i = 0; i < elements.length; i++) {
+      var element = elements[i];
+      var iso = element.getAttribute('datetime');
+      if (!iso) {
+        continue;
+      }
+      try {
+        var date = new Date(iso);
+        if (isNaN(date.getTime())) {
+          continue;
+        }
+        element.textContent = date.toLocaleDateString(undefined, {
+          year: 'numeric',
+          month: 'long',
+          day: 'numeric',
+        });
+      } catch (error) {
+        // Leave the UTC fallback text untouched.
+      }
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', localize);
+  } else {
+    localize();
+  }
+})();

--- a/src/documenteer/assets/rubin-pydata-theme.css
+++ b/src/documenteer/assets/rubin-pydata-theme.css
@@ -109,3 +109,11 @@ body {
 .navbar-nav i {
   font-size: var(--pst-font-size-icon);
 }
+
+/* "Last updated" timestamp at the bottom of the article body
+ * (documenteer.ext.lastmodified -> pydata "last-updated" component). */
+.bd-footer-article .last-updated {
+  text-align: left;
+  font-size: 0.875em;
+  color: var(--pst-color-text-muted);
+}

--- a/src/documenteer/assets/rubin-pydata-theme.css
+++ b/src/documenteer/assets/rubin-pydata-theme.css
@@ -111,9 +111,23 @@ body {
 }
 
 /* "Last updated" timestamp at the bottom of the article body
- * (documenteer.ext.lastmodified -> pydata "last-updated" component). */
+ * (documenteer.ext.lastmodified -> pydata "last-updated" component).
+ * Left-aligned, muted, with breathing room above and below so it reads as
+ * page metadata between the body and the prev/next navigation. */
 .bd-footer-article .last-updated {
+  margin-top: 1.5rem;
+  margin-bottom: 0.5rem;
   text-align: left;
   font-size: 0.875em;
   color: var(--pst-color-text-muted);
+}
+
+/* Indent the footer so the timestamp lines up with the article body text.
+ * pydata-sphinx-theme only indents the article (.bd-article) by 2rem at
+ * >=1200px, so match that breakpoint to avoid over-indenting on narrow
+ * screens, where the body has no extra indent. */
+@media (min-width: 1200px) {
+  .bd-footer-article {
+    padding-left: 2rem;
+  }
 }

--- a/src/documenteer/conf/_toml.py
+++ b/src/documenteer/conf/_toml.py
@@ -198,6 +198,14 @@ class ThemeModel(BaseModel):
         ),
     )
 
+    show_last_updated: bool = Field(
+        True,
+        description=(
+            "Show a 'Last updated' footer timestamp derived from Git commit "
+            "dates if True"
+        ),
+    )
+
 
 class SphinxModel(BaseModel):
     """Model for Sphinx configurations in documenteer.toml."""
@@ -565,3 +573,13 @@ class DocumenteerConfig:
             return self.conf.sphinx.theme.header_links_before_dropdown
         else:
             return 5
+
+    @property
+    def show_last_updated(self) -> bool:
+        """Whether to show a "Last updated" footer timestamp derived from Git
+        commit dates.
+        """
+        if self.conf.sphinx:
+            return self.conf.sphinx.theme.show_last_updated
+        else:
+            return True

--- a/src/documenteer/conf/_toml.py
+++ b/src/documenteer/conf/_toml.py
@@ -201,8 +201,8 @@ class ThemeModel(BaseModel):
     show_last_updated: bool = Field(
         True,
         description=(
-            "Show a 'Last updated' footer timestamp derived from Git commit "
-            "dates if True"
+            "Show a 'Last updated' timestamp at the bottom of each page "
+            "derived from Git commit dates if True"
         ),
     )
 
@@ -576,8 +576,8 @@ class DocumenteerConfig:
 
     @property
     def show_last_updated(self) -> bool:
-        """Whether to show a "Last updated" footer timestamp derived from Git
-        commit dates.
+        """Whether to show a "Last updated" timestamp at the bottom of each
+        page derived from Git commit dates.
         """
         if self.conf.sphinx:
             return self.conf.sphinx.theme.show_last_updated

--- a/src/documenteer/conf/_utils.py
+++ b/src/documenteer/conf/_utils.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+from datetime import datetime
 from pathlib import Path
 
 from git import Repo
@@ -107,6 +109,10 @@ class GitRepository:
 
     def __init__(self, dirname: Path) -> None:
         self._repo = Repo(dirname, search_parent_directories=True)
+        # Cache of the last-modified datetime for each absolute path so that
+        # shared dependencies (e.g. included files) are only resolved once per
+        # build, rather than once per referencing page.
+        self._last_modified_cache: dict[str, datetime | None] = {}
 
     @property
     def working_tree_dir(self) -> Path:
@@ -115,6 +121,70 @@ class GitRepository:
         if path is None:
             raise RuntimeError("Git repository is not available.")
         return Path(path)
+
+    @property
+    def is_shallow(self) -> bool:
+        """Whether the repository is a shallow clone.
+
+        A shallow clone (such as one produced by ``actions/checkout`` without
+        ``fetch-depth: 0``) does not contain the full commit history, so
+        commit-date lookups are unreliable.
+        """
+        result = self._repo.git.rev_parse("--is-shallow-repository")
+        return result.strip() == "true"
+
+    def compute_last_modified(
+        self, paths: Sequence[Path | str]
+    ) -> datetime | None:
+        """Compute the most-recent commit datetime across a set of paths.
+
+        Parameters
+        ----------
+        paths
+            Paths to consider. Typically a page's source file together with
+            any files it pulls in via ``include``/``literalinclude``.
+
+        Returns
+        -------
+        datetime.datetime or None
+            The most recent commit datetime (timezone-aware) across all of the
+            tracked ``paths``. Paths that are untracked (e.g. new or
+            uncommitted files), or that lie outside the Git working tree, are
+            ignored. Returns `None` if none of the paths are tracked in the
+            repository.
+        """
+        working_tree_dir = self.working_tree_dir.resolve()
+        datetimes: list[datetime] = []
+        for path in paths:
+            abs_path = Path(path).resolve()
+
+            # Defensively skip paths that aren't inside the working tree; Git
+            # cannot report history for them.
+            if not abs_path.is_relative_to(working_tree_dir):
+                continue
+
+            key = str(abs_path)
+            if key in self._last_modified_cache:
+                cached = self._last_modified_cache[key]
+            else:
+                cached = self._get_path_last_modified(abs_path)
+                self._last_modified_cache[key] = cached
+
+            if cached is not None:
+                datetimes.append(cached)
+
+        if not datetimes:
+            return None
+        return max(datetimes)
+
+    def _get_path_last_modified(self, path: Path) -> datetime | None:
+        """Get the datetime of the most recent commit touching a single path,
+        or `None` if the path isn't tracked.
+        """
+        commits = list(self._repo.iter_commits(paths=str(path), max_count=1))
+        if not commits:
+            return None
+        return commits[0].committed_datetime
 
 
 def extend_excludes_for_non_index_source(

--- a/src/documenteer/conf/guide.py
+++ b/src/documenteer/conf/guide.py
@@ -89,6 +89,7 @@ __all__ = [
     "html_baseurl",
     "html_static_path",
     "html_css_files",
+    "html_js_files",
     "html_show_sourcelink",
     "favicons",
     "sitemap_url_scheme",
@@ -368,6 +369,14 @@ html_static_path: list[str] = [
 ]
 
 html_css_files = ["rubin-pydata-theme.css"]
+
+# The lastmodified extension renders the per-page "last modified" footer date
+# as a <time> element; rubin-last-modified.js localizes it to the reader's
+# timezone. Only ship the script when the feature is enabled.
+html_js_files: list[str] = []
+if documenteer_last_modified_enabled:
+    html_static_path.append(get_asset_path("rubin-last-modified.js"))
+    html_js_files.append("rubin-last-modified.js")
 
 # If true, links to the reST sources are added to the pages.
 html_show_sourcelink = False

--- a/src/documenteer/conf/guide.py
+++ b/src/documenteer/conf/guide.py
@@ -294,13 +294,14 @@ html_theme_options = {
     },
 }
 
-# Show a "Last updated on <date>." footer timestamp on each page, derived from
-# Git commit history by documenteer.ext.lastmodified. When enabled, add
-# pydata-sphinx-theme's built-in "last-updated" component to the footer's
-# center slot (which is empty by default).
+# Show a "Last updated on <date>." timestamp at the bottom of each page's
+# article body, derived from Git commit history by
+# documenteer.ext.lastmodified. When enabled, add pydata-sphinx-theme's
+# built-in "last-updated" component to the article footer slot (which is empty
+# by default).
 documenteer_last_modified_enabled = _conf.show_last_updated
 if documenteer_last_modified_enabled:
-    html_theme_options["footer_center"] = ["last-updated"]
+    html_theme_options["article_footer_items"] = ["last-updated"]
 
 if _conf.github_url:
     if not isinstance(html_theme_options["icon_links"], list):

--- a/src/documenteer/conf/guide.py
+++ b/src/documenteer/conf/guide.py
@@ -81,6 +81,7 @@ __all__ = [
     "html_theme",
     "html_context",
     "html_theme_options",
+    "documenteer_last_modified_enabled",
     "html_sidebars",
     "html_title",
     "html_short_title",
@@ -168,6 +169,7 @@ extensions = [
     "sphinx_favicon",
     "sphinx_sitemap",
     "documenteer.ext.robots",
+    "documenteer.ext.lastmodified",
     "documenteer.ext.jira",
     "documenteer.ext.lsstdocushare",
     "documenteer.ext.mockcoderefs",
@@ -291,6 +293,14 @@ html_theme_options = {
         "plausible_analytics_url": "https://plausible.io/js/script.file-downloads.hash.outbound-links.js",
     },
 }
+
+# Show a "Last updated on <date>." footer timestamp on each page, derived from
+# Git commit history by documenteer.ext.lastmodified. When enabled, add
+# pydata-sphinx-theme's built-in "last-updated" component to the footer's
+# center slot (which is empty by default).
+documenteer_last_modified_enabled = _conf.show_last_updated
+if documenteer_last_modified_enabled:
+    html_theme_options["footer_center"] = ["last-updated"]
 
 if _conf.github_url:
     if not isinstance(html_theme_options["icon_links"], list):

--- a/src/documenteer/conf/guide.py
+++ b/src/documenteer/conf/guide.py
@@ -82,6 +82,7 @@ __all__ = [
     "html_context",
     "html_theme_options",
     "documenteer_last_modified_enabled",
+    "git_last_updated_metatags",
     "html_sidebars",
     "html_title",
     "html_short_title",
@@ -302,6 +303,11 @@ html_theme_options = {
 documenteer_last_modified_enabled = _conf.show_last_updated
 if documenteer_last_modified_enabled:
     html_theme_options["article_footer_items"] = ["last-updated"]
+
+# documenteer.ext.lastmodified now emits article:modified_time itself, so
+# turn off the duplicate tag from sphinx-last-updated-by-git (auto-loaded by
+# sphinx-sitemap, which still uses it for sitemap <lastmod>).
+git_last_updated_metatags = False
 
 if _conf.github_url:
     if not isinstance(html_theme_options["icon_links"], list):

--- a/src/documenteer/ext/lastmodified.py
+++ b/src/documenteer/ext/lastmodified.py
@@ -5,7 +5,8 @@ For each HTML output page, this extension computes the most recent commit
 datetime across the page's source file *and* any files that the page pulls in
 via ``include``/``literalinclude`` directives. That datetime is formatted and
 stored in the page's ``last_updated`` template context variable, which the
-pydata-sphinx-theme renders in its ``last-updated`` footer component.
+pydata-sphinx-theme renders at the bottom of the article body via its
+``last-updated`` component.
 
 Using Git commit dates (rather than filesystem modification times) means the
 timestamps are meaningful in CI builds, where checkouts have arbitrary mtimes.

--- a/src/documenteer/ext/lastmodified.py
+++ b/src/documenteer/ext/lastmodified.py
@@ -3,10 +3,26 @@ on the page's Git commit history.
 
 For each HTML output page, this extension computes the most recent commit
 datetime across the page's source file *and* any files that the page pulls in
-via ``include``/``literalinclude`` directives. That datetime is formatted and
-stored in the page's ``last_updated`` template context variable, which the
-pydata-sphinx-theme renders at the bottom of the article body via its
-``last-updated`` component.
+via ``include``/``literalinclude`` directives.
+
+That datetime is exposed to the page template in three forms:
+
+- ``last_updated`` -- the date formatted with
+  ``documenteer_last_modified_date_format`` in the *commit's* timezone offset.
+  Sphinx emits this as the ``docbuild:last-update`` meta tag, and it is the
+  value any theme-agnostic ``last-updated`` rendering uses.
+- ``documenteer_last_modified_iso`` -- the canonical UTC ISO 8601 timestamp
+  (for example ``2024-06-01T00:00:00+00:00``).
+- ``documenteer_last_modified_date`` -- the UTC date as ``YYYY-MM-DD`` (for
+  example ``2024-06-01``).
+
+Documenteer's user-guide preset overrides pydata-sphinx-theme's
+``last-updated`` component (``src/documenteer/templates/pydata/
+last-updated.html``) to render "This page was last modified on <date>." as a
+``<time>`` element. Its ``datetime`` attribute carries
+``documenteer_last_modified_iso`` and its visible text is
+``documenteer_last_modified_date`` (the UTC ``YYYY-MM-DD`` fallback);
+``rubin-last-modified.js`` rewrites that text to the reader's local date.
 
 The same datetime is also emitted into the page ``<head>`` as machine-readable
 metadata -- ``article:modified_time`` (Open Graph), ``dcterms.modified``
@@ -46,9 +62,22 @@ logger = logging.getLogger(__name__)
 class LastModified:
     """Computes per-page "last modified" timestamps from Git commit history.
 
-    A single instance is created in `setup` and its
-    `add_last_modified` method is connected to the ``html-page-context``
-    event. The instance lazily constructs a ``GitRepository`` on first use and
+    A single instance is created in `setup`, which connects two
+    ``html-page-context`` handlers:
+
+    - `add_time_context` (early, before pydata-sphinx-theme's
+      ``update_and_remove_templates``) exposes the UTC ``<time>`` context
+      variables. pydata empty-checks the ``last-updated`` footer component and
+      drops it unless these variables already exist when it runs, so they must
+      be set first.
+    - `add_last_modified` (late, after sphinx-last-updated-by-git's own
+      handler) sets the human-readable ``last_updated`` value and appends the
+      machine-readable ``<head>`` metadata.
+
+    Both handlers share a single per-page Git computation via
+    `get_last_modified_datetime`, which is memoized in ``_date_cache``.
+
+    The instance lazily constructs a ``GitRepository`` on first use and
     remembers when timestamps can't be produced, so that those builds are a
     clean no-op. Timestamps are disabled when the source directory isn't a Git
     repository (including the pytest temporary source directory) and when the
@@ -61,6 +90,9 @@ class LastModified:
         # True once we've determined the srcdir isn't a usable Git repository,
         # so we don't retry (and re-log) on every page.
         self._disabled = False
+        # Per-page memo of the computed last-modified datetime, so the two
+        # html-page-context handlers don't each run the Git computation.
+        self._date_cache: dict[str, datetime | None] = {}
 
     def _get_repository(self, app: Sphinx) -> GitRepository | None:
         """Get the cached ``GitRepository``, constructing it on first use.
@@ -135,7 +167,42 @@ class LastModified:
 
         return repo.compute_last_modified(paths)
 
-    def add_last_modified(
+    def _resolve(
+        self, app: Sphinx, pagename: str, doctree: object | None
+    ) -> datetime | None:
+        """Return the page's last-modified datetime, applying the gates once.
+
+        Shared by both ``html-page-context`` handlers. The result is memoized
+        per page so the (potentially expensive) Git computation runs only once
+        even though two handlers consult it.
+
+        Returns `None` -- so the caller emits nothing -- when the page has no
+        source document, the feature is disabled, or no commit date is
+        available.
+
+        Parameters
+        ----------
+        app
+            The Sphinx application.
+        pagename
+            The docname of the page being rendered.
+        doctree
+            The doctree for the page, or `None` for pages without a source
+            document (such as ``genindex``, ``search``, and ``404``). These
+            pages are skipped.
+        """
+        if doctree is None:
+            # Pages such as genindex/search/404 have no source file.
+            return None
+        if not app.config.documenteer_last_modified_enabled:
+            return None
+        if pagename not in self._date_cache:
+            self._date_cache[pagename] = self.get_last_modified_datetime(
+                app, pagename
+            )
+        return self._date_cache[pagename]
+
+    def add_time_context(
         self,
         app: Sphinx,
         pagename: str,
@@ -143,14 +210,20 @@ class LastModified:
         context: dict,
         doctree: object | None,
     ) -> None:
-        """Populate the last-modified context and metadata for a page.
+        """Expose the UTC ``<time>`` context variables for the footer.
 
-        This is the ``html-page-context`` event handler. It runs once per
-        output page, immediately before the page is rendered. It sets the
-        ``last_updated`` context value (rendered in the article footer and
-        emitted by pydata-sphinx-theme as the ``docbuild:last-update`` meta
-        tag) and appends machine-readable last-modified metadata to the page's
-        ``<head>``.
+        This ``html-page-context`` handler runs *early* -- before
+        pydata-sphinx-theme's ``update_and_remove_templates`` (priority 500),
+        which empty-checks the ``last-updated`` footer component and drops it
+        unless its context is already populated. Documenteer's override of that
+        component renders a ``<time>`` element gated on
+        ``documenteer_last_modified_iso``, so this handler must set it first:
+
+        - ``documenteer_last_modified_iso`` -- the canonical UTC ISO 8601
+          timestamp, used in the ``<time datetime="...">`` attribute (which
+          ``rubin-last-modified.js`` localizes to the reader's timezone).
+        - ``documenteer_last_modified_date`` -- the UTC date as ``YYYY-MM-DD``,
+          the no-JavaScript visible fallback text.
 
         Parameters
         ----------
@@ -164,17 +237,56 @@ class LastModified:
             The template context, modified in place.
         doctree
             The doctree for the page, or `None` for pages without a source
-            document (such as ``genindex``, ``search``, and ``404``). These
-            pages are skipped.
+            document (such pages are skipped).
         """
-        if doctree is None:
-            # Pages such as genindex/search/404 have no source file.
+        date = self._resolve(app, pagename, doctree)
+        if date is None:
             return
 
-        if not app.config.documenteer_last_modified_enabled:
-            return
+        utc_date = date.astimezone(UTC)
+        context["documenteer_last_modified_iso"] = utc_date.isoformat()
+        context["documenteer_last_modified_date"] = utc_date.strftime(
+            "%Y-%m-%d"
+        )
 
-        date = self.get_last_modified_datetime(app, pagename)
+    def add_last_modified(
+        self,
+        app: Sphinx,
+        pagename: str,
+        templatename: str,
+        context: dict,
+        doctree: object | None,
+    ) -> None:
+        """Populate the ``last_updated`` value and ``<head>`` metadata.
+
+        This ``html-page-context`` handler runs *late* -- after
+        sphinx-last-updated-by-git's own handler (which the user-guide preset
+        auto-loads through sphinx-sitemap and which resets ``last_updated`` to
+        `None` when ``html_last_updated_fmt`` is unset) and after
+        pydata-sphinx-theme's ``_fix_canonical_url`` (so the JSON-LD metadata
+        sees the corrected ``pageurl``). It sets the ``last_updated`` context
+        value -- formatted in the commit's own timezone offset and emitted by
+        pydata-sphinx-theme as the ``docbuild:last-update`` meta tag -- and
+        appends machine-readable last-modified metadata to the page ``<head>``.
+
+        The ``<time>`` footer context variables are set separately and earlier
+        by `add_time_context`.
+
+        Parameters
+        ----------
+        app
+            The Sphinx application.
+        pagename
+            The docname of the page being rendered.
+        templatename
+            The template used to render the page.
+        context
+            The template context, modified in place.
+        doctree
+            The doctree for the page, or `None` for pages without a source
+            document (such pages are skipped).
+        """
+        date = self._resolve(app, pagename, doctree)
         if date is None:
             return
 
@@ -190,10 +302,10 @@ class LastModified:
             language=app.config.language,
         )
 
-        self._add_metadata(context, date)
+        self._add_metadata(context, date.astimezone(UTC).isoformat())
 
     @staticmethod
-    def _add_metadata(context: dict, date: datetime) -> None:
+    def _add_metadata(context: dict, iso: str) -> None:
         """Append machine-readable last-modified metadata to the page head.
 
         Emits the page's Git commit date through three complementary channels,
@@ -206,24 +318,22 @@ class LastModified:
           keeps this a plain freshness statement without triggering the
           "missing field" validation noise that an ``Article`` would.
 
-        The ISO value is normalized to UTC (``+00:00``), independent of the
-        committer's timezone offset, so these machine-readable freshness
-        signals are byte-for-byte identical no matter who authored the commit
-        (a local commit and its UTC-recorded squash-merge agree). This
-        deliberately diverges from the human-readable footer date, which keeps
-        the commit's own offset.
+        The ISO value is normalized to UTC (``+00:00``) by the caller,
+        independent of the committer's timezone offset, so these
+        machine-readable freshness signals are byte-for-byte identical no
+        matter who authored the commit (a local commit and its UTC-recorded
+        squash-merge agree). This deliberately diverges from the
+        human-readable ``last_updated`` footer date, which keeps the commit's
+        own offset.
 
         Parameters
         ----------
         context
             The template context, modified in place. Its ``metatags`` string
             is extended with the new tags.
-        date
-            The timezone-aware last-modified datetime.
+        iso
+            The canonical UTC ISO 8601 last-modified timestamp.
         """
-        # Normalize to UTC so the machine-readable metadata is canonical and
-        # contributor-independent, not tied to the committer's local offset.
-        iso = date.astimezone(UTC).isoformat()
         metatags = context.get("metatags", "")
 
         metatags += (
@@ -261,14 +371,26 @@ def setup(app: Sphinx) -> ExtensionMetadata:
         "documenteer_last_modified_date_format", "%b %d, %Y", "html", [str]
     )
 
-    # A single instance carries the cached Git repository across all pages in
-    # a build.
+    # A single instance carries the cached Git repository and per-page date
+    # memo across all pages in a build.
     last_modified = LastModified()
-    # Connect with an explicit later priority (the default is 500; higher
-    # numbers run later) so this handler deterministically wins over
-    # sphinx_last_updated_by_git's html-page-context handler -- which also
-    # writes ``last_updated`` -- regardless of the order the extensions appear
-    # in the extensions list. The last writer wins, and we want it to be us.
+
+    # The two handlers bracket the default-priority (500) html-page-context
+    # handlers of the themes/extensions we coexist with (lower numbers run
+    # earlier):
+    #
+    # - add_time_context runs early (priority 400) so the
+    #   documenteer_last_modified_iso/date context variables exist *before*
+    #   pydata-sphinx-theme's update_and_remove_templates (priority 500)
+    #   empty-checks the overridden last-updated footer component. Without
+    #   this, that component renders empty and pydata drops it from the footer.
+    # - add_last_modified runs late (priority 600) so it deterministically
+    #   wins ``last_updated`` over sphinx_last_updated_by_git's priority-500
+    #   handler (which resets it to None) and so the JSON-LD metadata sees the
+    #   pageurl that pydata's _fix_canonical_url (priority 500) corrects.
+    app.connect(
+        "html-page-context", last_modified.add_time_context, priority=400
+    )
     app.connect(
         "html-page-context", last_modified.add_last_modified, priority=600
     )

--- a/src/documenteer/ext/lastmodified.py
+++ b/src/documenteer/ext/lastmodified.py
@@ -26,7 +26,7 @@ timestamps are meaningful in CI builds, where checkouts have arbitrary mtimes.
 from __future__ import annotations
 
 import json
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 
 import git
@@ -206,6 +206,13 @@ class LastModified:
           keeps this a plain freshness statement without triggering the
           "missing field" validation noise that an ``Article`` would.
 
+        The ISO value is normalized to UTC (``+00:00``), independent of the
+        committer's timezone offset, so these machine-readable freshness
+        signals are byte-for-byte identical no matter who authored the commit
+        (a local commit and its UTC-recorded squash-merge agree). This
+        deliberately diverges from the human-readable footer date, which keeps
+        the commit's own offset.
+
         Parameters
         ----------
         context
@@ -214,7 +221,9 @@ class LastModified:
         date
             The timezone-aware last-modified datetime.
         """
-        iso = date.isoformat()
+        # Normalize to UTC so the machine-readable metadata is canonical and
+        # contributor-independent, not tied to the committer's local offset.
+        iso = date.astimezone(UTC).isoformat()
         metatags = context.get("metatags", "")
 
         metatags += (

--- a/src/documenteer/ext/lastmodified.py
+++ b/src/documenteer/ext/lastmodified.py
@@ -1,0 +1,198 @@
+"""Sphinx extension that adds a "Last updated" timestamp to each page based
+on the page's Git commit history.
+
+For each HTML output page, this extension computes the most recent commit
+datetime across the page's source file *and* any files that the page pulls in
+via ``include``/``literalinclude`` directives. That datetime is formatted and
+stored in the page's ``last_updated`` template context variable, which the
+pydata-sphinx-theme renders in its ``last-updated`` footer component.
+
+Using Git commit dates (rather than filesystem modification times) means the
+timestamps are meaningful in CI builds, where checkouts have arbitrary mtimes.
+
+.. important::
+
+   The date is derived from the Git history, so CI checkouts must fetch the
+   full history. With ``actions/checkout`` set ``fetch-depth: 0``; a shallow
+   clone makes every page report the same (wrong) date.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import git
+from sphinx.application import Sphinx
+from sphinx.util import logging
+from sphinx.util.i18n import format_date
+from sphinx.util.typing import ExtensionMetadata
+
+from ..conf._utils import GitRepository
+from ..version import __version__
+
+__all__ = ["LastModified", "setup"]
+
+logger = logging.getLogger(__name__)
+
+
+class LastModified:
+    """Computes per-page "last modified" timestamps from Git commit history.
+
+    A single instance is created in `setup` and its
+    `add_last_modified` method is connected to the ``html-page-context``
+    event. The instance lazily constructs a ``GitRepository`` on first use and
+    remembers when timestamps can't be produced, so that those builds are a
+    clean no-op. Timestamps are disabled when the source directory isn't a Git
+    repository (including the pytest temporary source directory) and when the
+    repository is a shallow clone (whose truncated history would yield
+    misleading dates -- a warning is emitted in that case).
+    """
+
+    def __init__(self) -> None:
+        self._repo: GitRepository | None = None
+        # True once we've determined the srcdir isn't a usable Git repository,
+        # so we don't retry (and re-log) on every page.
+        self._disabled = False
+
+    def _get_repository(self, app: Sphinx) -> GitRepository | None:
+        """Get the cached ``GitRepository``, constructing it on first use.
+
+        Returns `None` if the source directory isn't a Git repository.
+        """
+        if self._disabled:
+            return None
+        if self._repo is None:
+            try:
+                self._repo = GitRepository(Path(app.srcdir))
+            except (git.InvalidGitRepositoryError, git.NoSuchPathError):
+                self._disabled = True
+                logger.debug(
+                    "documenteer.ext.lastmodified: %s is not a Git "
+                    "repository; skipping 'last updated' timestamps.",
+                    app.srcdir,
+                )
+                return None
+            if self._repo.is_shallow:
+                # A shallow clone lacks the full history, so commit dates
+                # collapse to the boundary commit's date. Rather than publish
+                # misleading timestamps, disable the feature entirely (and warn
+                # once) until the repository is fetched with full history.
+                self._disabled = True
+                self._repo = None
+                logger.warning(
+                    "documenteer.ext.lastmodified: the Git repository is a "
+                    "shallow clone, so 'last updated' page timestamps would "
+                    "be inaccurate and have been omitted. In CI, configure "
+                    "actions/checkout with fetch-depth: 0 to fetch the full "
+                    "history and enable them."
+                )
+                return None
+        return self._repo
+
+    def get_last_modified(self, app: Sphinx, pagename: str) -> str | None:
+        """Compute the formatted "last updated" date for a page.
+
+        Parameters
+        ----------
+        app
+            The Sphinx application.
+        pagename
+            The docname of the page being rendered.
+
+        Returns
+        -------
+        str or None
+            The formatted date, or `None` if there's no Git repository or none
+            of the page's source/dependency files are tracked.
+        """
+        repo = self._get_repository(app)
+        if repo is None:
+            return None
+
+        # The page's own source file (absolute path).
+        source = Path(app.env.doc2path(pagename, base=True))
+
+        # Files the page depends on (includes/literalinclude). Sphinx records
+        # these as forward-slash paths that are either srcdir-relative or
+        # absolute; the ``/`` operator handles both (an absolute dependency
+        # replaces srcdir, mirroring os.path.join). compute_last_modified
+        # resolves each path, so no explicit normalization is needed here.
+        srcdir = Path(app.env.srcdir)
+        dependencies = app.env.dependencies.get(pagename, set())
+        paths: list[Path] = [source, *(srcdir / dep for dep in dependencies)]
+
+        date = repo.compute_last_modified(paths)
+        if date is None:
+            return None
+
+        fmt = app.config.documenteer_last_modified_date_format
+        # Don't pass ``local_time``: it was only added to format_date() in
+        # Sphinx 8 (where it defaults to False), and Sphinx 7 formats the date
+        # as given. Relying on the default keeps output reproducible (the
+        # commit datetime is used as-is, not converted to the builder's local
+        # timezone) and compatible across both Sphinx versions.
+        return format_date(
+            fmt,
+            date=date,
+            language=app.config.language,
+        )
+
+    def add_last_modified(
+        self,
+        app: Sphinx,
+        pagename: str,
+        templatename: str,
+        context: dict,
+        doctree: object | None,
+    ) -> None:
+        """Populate the ``last_updated`` template context for a page.
+
+        This is the ``html-page-context`` event handler. It runs once per
+        output page, immediately before the page is rendered.
+
+        Parameters
+        ----------
+        app
+            The Sphinx application.
+        pagename
+            The docname of the page being rendered.
+        templatename
+            The template used to render the page.
+        context
+            The template context, modified in place.
+        doctree
+            The doctree for the page, or `None` for pages without a source
+            document (such as ``genindex``, ``search``, and ``404``). These
+            pages are skipped.
+        """
+        if doctree is None:
+            # Pages such as genindex/search/404 have no source file.
+            return
+
+        if not app.config.documenteer_last_modified_enabled:
+            return
+
+        formatted = self.get_last_modified(app, pagename)
+        if formatted is not None:
+            context["last_updated"] = formatted
+
+
+def setup(app: Sphinx) -> ExtensionMetadata:
+    """Set up the ``documenteer.ext.lastmodified`` Sphinx extension."""
+    app.add_config_value(
+        "documenteer_last_modified_enabled", True, "html", [bool]
+    )
+    app.add_config_value(
+        "documenteer_last_modified_date_format", "%b %d, %Y", "html", [str]
+    )
+
+    # A single instance carries the cached Git repository across all pages in
+    # a build.
+    last_modified = LastModified()
+    app.connect("html-page-context", last_modified.add_last_modified)
+
+    return {
+        "version": __version__,
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/src/documenteer/ext/lastmodified.py
+++ b/src/documenteer/ext/lastmodified.py
@@ -8,6 +8,11 @@ stored in the page's ``last_updated`` template context variable, which the
 pydata-sphinx-theme renders at the bottom of the article body via its
 ``last-updated`` component.
 
+The same datetime is also emitted into the page ``<head>`` as machine-readable
+metadata -- ``article:modified_time`` (Open Graph), ``dcterms.modified``
+(Dublin Core), and a Schema.org ``dateModified`` (JSON-LD) -- so that this
+extension is the single source of truth for the page's last-modified date.
+
 Using Git commit dates (rather than filesystem modification times) means the
 timestamps are meaningful in CI builds, where checkouts have arbitrary mtimes.
 
@@ -20,6 +25,8 @@ timestamps are meaningful in CI builds, where checkouts have arbitrary mtimes.
 
 from __future__ import annotations
 
+import json
+from datetime import datetime
 from pathlib import Path
 
 import git
@@ -90,8 +97,10 @@ class LastModified:
                 return None
         return self._repo
 
-    def get_last_modified(self, app: Sphinx, pagename: str) -> str | None:
-        """Compute the formatted "last updated" date for a page.
+    def get_last_modified_datetime(
+        self, app: Sphinx, pagename: str
+    ) -> datetime | None:
+        """Compute the most recent Git commit datetime for a page.
 
         Parameters
         ----------
@@ -102,9 +111,11 @@ class LastModified:
 
         Returns
         -------
-        str or None
-            The formatted date, or `None` if there's no Git repository or none
-            of the page's source/dependency files are tracked.
+        datetime.datetime or None
+            The timezone-aware datetime of the most recent commit touching the
+            page's own source file or any of its ``include``/``literalinclude``
+            dependencies, or `None` if there's no Git repository or none of
+            those files are tracked.
         """
         repo = self._get_repository(app)
         if repo is None:
@@ -122,21 +133,7 @@ class LastModified:
         dependencies = app.env.dependencies.get(pagename, set())
         paths: list[Path] = [source, *(srcdir / dep for dep in dependencies)]
 
-        date = repo.compute_last_modified(paths)
-        if date is None:
-            return None
-
-        fmt = app.config.documenteer_last_modified_date_format
-        # Don't pass ``local_time``: it was only added to format_date() in
-        # Sphinx 8 (where it defaults to False), and Sphinx 7 formats the date
-        # as given. Relying on the default keeps output reproducible (the
-        # commit datetime is used as-is, not converted to the builder's local
-        # timezone) and compatible across both Sphinx versions.
-        return format_date(
-            fmt,
-            date=date,
-            language=app.config.language,
-        )
+        return repo.compute_last_modified(paths)
 
     def add_last_modified(
         self,
@@ -146,10 +143,14 @@ class LastModified:
         context: dict,
         doctree: object | None,
     ) -> None:
-        """Populate the ``last_updated`` template context for a page.
+        """Populate the last-modified context and metadata for a page.
 
         This is the ``html-page-context`` event handler. It runs once per
-        output page, immediately before the page is rendered.
+        output page, immediately before the page is rendered. It sets the
+        ``last_updated`` context value (rendered in the article footer and
+        emitted by pydata-sphinx-theme as the ``docbuild:last-update`` meta
+        tag) and appends machine-readable last-modified metadata to the page's
+        ``<head>``.
 
         Parameters
         ----------
@@ -173,9 +174,73 @@ class LastModified:
         if not app.config.documenteer_last_modified_enabled:
             return
 
-        formatted = self.get_last_modified(app, pagename)
-        if formatted is not None:
-            context["last_updated"] = formatted
+        date = self.get_last_modified_datetime(app, pagename)
+        if date is None:
+            return
+
+        fmt = app.config.documenteer_last_modified_date_format
+        # Don't pass ``local_time``: it was only added to format_date() in
+        # Sphinx 8 (where it defaults to False), and Sphinx 7 formats the date
+        # as given. Relying on the default keeps output reproducible (the
+        # commit datetime is used as-is, not converted to the builder's local
+        # timezone) and compatible across both Sphinx versions.
+        context["last_updated"] = format_date(
+            fmt,
+            date=date,
+            language=app.config.language,
+        )
+
+        self._add_metadata(context, date)
+
+    @staticmethod
+    def _add_metadata(context: dict, date: datetime) -> None:
+        """Append machine-readable last-modified metadata to the page head.
+
+        Emits the page's Git commit date through three complementary channels,
+        all carrying the same ISO 8601 value, so that social-card scrapers,
+        Dublin Core harvesters, and Schema.org/JSON-LD crawlers agree:
+
+        - ``article:modified_time`` -- Open Graph.
+        - ``dcterms.modified`` -- Dublin Core.
+        - Schema.org ``dateModified`` on a ``WebPage`` -- JSON-LD. ``WebPage``
+          keeps this a plain freshness statement without triggering the
+          "missing field" validation noise that an ``Article`` would.
+
+        Parameters
+        ----------
+        context
+            The template context, modified in place. Its ``metatags`` string
+            is extended with the new tags.
+        date
+            The timezone-aware last-modified datetime.
+        """
+        iso = date.isoformat()
+        metatags = context.get("metatags", "")
+
+        metatags += (
+            f'\n<meta property="article:modified_time" content="{iso}" />'
+            f'\n<meta name="dcterms.modified" content="{iso}" />'
+        )
+
+        json_ld: dict[str, str] = {
+            "@context": "https://schema.org",
+            "@type": "WebPage",
+            "dateModified": iso,
+        }
+        # Guides set html_baseurl, so pageurl is usually available; tie the
+        # statement to the page's canonical URL when it is.
+        pageurl = context.get("pageurl")
+        if pageurl:
+            json_ld["@id"] = pageurl
+            json_ld["url"] = pageurl
+        # Escape ``<`` so a value can never terminate the <script> element
+        # early (defense against early-script-termination injection).
+        serialized = json.dumps(json_ld).replace("<", "\\u003c")
+        metatags += (
+            f'\n<script type="application/ld+json">{serialized}</script>'
+        )
+
+        context["metatags"] = metatags
 
 
 def setup(app: Sphinx) -> ExtensionMetadata:
@@ -190,7 +255,14 @@ def setup(app: Sphinx) -> ExtensionMetadata:
     # A single instance carries the cached Git repository across all pages in
     # a build.
     last_modified = LastModified()
-    app.connect("html-page-context", last_modified.add_last_modified)
+    # Connect with an explicit later priority (the default is 500; higher
+    # numbers run later) so this handler deterministically wins over
+    # sphinx_last_updated_by_git's html-page-context handler -- which also
+    # writes ``last_updated`` -- regardless of the order the extensions appear
+    # in the extensions list. The last writer wins, and we want it to be us.
+    app.connect(
+        "html-page-context", last_modified.add_last_modified, priority=600
+    )
 
     return {
         "version": __version__,

--- a/src/documenteer/templates/pydata/last-updated.html
+++ b/src/documenteer/templates/pydata/last-updated.html
@@ -1,0 +1,14 @@
+{# Override of pydata-sphinx-theme's last-updated component.
+   Renders documenteer.ext.lastmodified's per-page Git commit date as a
+   localizable <time> element: the datetime attribute carries the canonical
+   UTC ISO 8601 timestamp; the visible text is the UTC date (YYYY-MM-DD) as a
+   no-JavaScript fallback, which rubin-last-modified.js rewrites to the
+   reader's local date. #}
+{%- if documenteer_last_modified_iso -%}
+<p class="last-updated">
+  This page was last modified on
+  <time datetime="{{ documenteer_last_modified_iso|e }}"
+        class="documenteer-last-modified"
+        data-documenteer-last-modified>{{ documenteer_last_modified_date|e }}</time>.
+</p>
+{%- endif -%}

--- a/tests/ext/lastmodified_test.py
+++ b/tests/ext/lastmodified_test.py
@@ -13,7 +13,7 @@ from sphinx.testing.util import SphinxTestApp
 FIXED_DATE = datetime(2024, 6, 1, tzinfo=UTC)
 EXPECTED = "Jun 01, 2024"
 
-# Whether pydata-sphinx-theme is importable. The end-to-end footer test must
+# Whether pydata-sphinx-theme is importable. The end-to-end render test must
 # be skipped *before* the ``app`` fixture is built, because building with
 # ``html_theme = "pydata_sphinx_theme"`` would otherwise error during fixture
 # setup when the theme isn't installed.
@@ -141,11 +141,11 @@ def test_last_updated_suppressed_for_shallow_clone(app: SphinxTestApp) -> None:
     srcdir="lastmodified-pydata",
     confoverrides={
         "html_theme": "pydata_sphinx_theme",
-        "html_theme_options": {"footer_center": ["last-updated"]},
+        "html_theme_options": {"article_footer_items": ["last-updated"]},
     },
 )
-def test_last_updated_rendered_in_pydata_footer(app: SphinxTestApp) -> None:
-    """End-to-end: the date appears in the rendered pydata footer."""
+def test_last_updated_rendered_in_pydata_article(app: SphinxTestApp) -> None:
+    """End-to-end: the date appears at the bottom of the rendered article."""
     mock_repo = _mock_git_repository()
     with patch(
         "documenteer.ext.lastmodified.GitRepository", return_value=mock_repo

--- a/tests/ext/lastmodified_test.py
+++ b/tests/ext/lastmodified_test.py
@@ -1,0 +1,156 @@
+# type: ignore
+"""Tests for documenteer.ext.lastmodified."""
+
+from __future__ import annotations
+
+import importlib.util
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sphinx.testing.util import SphinxTestApp
+
+FIXED_DATE = datetime(2024, 6, 1, tzinfo=UTC)
+EXPECTED = "Jun 01, 2024"
+
+# Whether pydata-sphinx-theme is importable. The end-to-end footer test must
+# be skipped *before* the ``app`` fixture is built, because building with
+# ``html_theme = "pydata_sphinx_theme"`` would otherwise error during fixture
+# setup when the theme isn't installed.
+_HAS_PYDATA = importlib.util.find_spec("pydata_sphinx_theme") is not None
+
+
+def _mock_git_repository() -> MagicMock:
+    """Build a mock GitRepository that always reports a fixed commit date."""
+    mock_repo = MagicMock()
+    mock_repo.is_shallow = False
+    mock_repo.compute_last_modified.return_value = FIXED_DATE
+    return mock_repo
+
+
+def _build_and_capture(
+    app: SphinxTestApp, mock_repo: MagicMock
+) -> dict[str, dict]:
+    """Build the app with GitRepository mocked, capturing each page's context.
+
+    The probe handler is connected after the extension's handler, so it
+    observes the ``last_updated`` value that the extension set (if any).
+    """
+    captured: dict[str, dict] = {}
+
+    def probe(app, pagename, templatename, context, doctree):
+        captured[pagename] = dict(context)
+
+    app.connect("html-page-context", probe)
+    with patch(
+        "documenteer.ext.lastmodified.GitRepository", return_value=mock_repo
+    ):
+        app.build()
+    return captured
+
+
+@pytest.mark.sphinx(
+    "html", testroot="lastmodified", srcdir="lastmodified-content"
+)
+def test_last_updated_on_content_pages(app: SphinxTestApp) -> None:
+    """Content pages get a formatted ``last_updated`` context value."""
+    mock_repo = _mock_git_repository()
+    captured = _build_and_capture(app, mock_repo)
+
+    assert captured["index"]["last_updated"] == EXPECTED
+    assert captured["page2"]["last_updated"] == EXPECTED
+
+    # The included snippet is among the paths considered for the index page,
+    # demonstrating that include/literalinclude dependencies are accounted for.
+    considered = [
+        str(path)
+        for call in mock_repo.compute_last_modified.call_args_list
+        for path in call.args[0]
+    ]
+    assert any(path.endswith("snippet.txt") for path in considered)
+
+
+@pytest.mark.sphinx(
+    "html", testroot="lastmodified", srcdir="lastmodified-special"
+)
+def test_last_updated_none_on_special_pages(app: SphinxTestApp) -> None:
+    """genindex/search pages (no source doctree) keep ``last_updated`` falsy.
+
+    Sphinx always seeds ``last_updated`` in the global context (as ``None``
+    when ``html_last_updated_fmt`` is unset). The extension leaves that value
+    untouched for sourceless pages, so the footer component (which renders
+    only when the value is truthy) stays hidden there.
+    """
+    mock_repo = _mock_git_repository()
+    captured = _build_and_capture(app, mock_repo)
+
+    assert captured["genindex"]["last_updated"] is None
+    assert captured["search"]["last_updated"] is None
+
+
+@pytest.mark.sphinx(
+    "html",
+    testroot="lastmodified",
+    srcdir="lastmodified-disabled",
+    confoverrides={"documenteer_last_modified_enabled": False},
+)
+def test_last_updated_disabled(app: SphinxTestApp) -> None:
+    """When disabled, no page gets a date and Git is not consulted.
+
+    The ``last_updated`` key remains at Sphinx's default of ``None`` because
+    the extension returns early before consulting Git.
+    """
+    mock_repo = _mock_git_repository()
+    captured = _build_and_capture(app, mock_repo)
+
+    assert captured["index"]["last_updated"] is None
+    assert captured["page2"]["last_updated"] is None
+    mock_repo.compute_last_modified.assert_not_called()
+
+
+@pytest.mark.sphinx(
+    "html", testroot="lastmodified", srcdir="lastmodified-shallow"
+)
+def test_last_updated_suppressed_for_shallow_clone(app: SphinxTestApp) -> None:
+    """A shallow clone suppresses dates entirely and warns once.
+
+    Showing the boundary commit's date for every page would publish
+    misleading data, so the extension omits the timestamp instead.
+    """
+    mock_repo = _mock_git_repository()
+    mock_repo.is_shallow = True
+    captured = _build_and_capture(app, mock_repo)
+
+    # No page gets a date, and Git is never consulted for commit history.
+    assert captured["index"]["last_updated"] is None
+    assert captured["page2"]["last_updated"] is None
+    mock_repo.compute_last_modified.assert_not_called()
+
+    # The user is warned exactly once about the shallow clone.
+    warnings = app.warning.getvalue()
+    assert warnings.count("shallow clone") == 1
+    assert "fetch-depth: 0" in warnings
+
+
+@pytest.mark.skipif(
+    not _HAS_PYDATA, reason="pydata_sphinx_theme is not installed"
+)
+@pytest.mark.sphinx(
+    "html",
+    testroot="lastmodified",
+    srcdir="lastmodified-pydata",
+    confoverrides={
+        "html_theme": "pydata_sphinx_theme",
+        "html_theme_options": {"footer_center": ["last-updated"]},
+    },
+)
+def test_last_updated_rendered_in_pydata_footer(app: SphinxTestApp) -> None:
+    """End-to-end: the date appears in the rendered pydata footer."""
+    mock_repo = _mock_git_repository()
+    with patch(
+        "documenteer.ext.lastmodified.GitRepository", return_value=mock_repo
+    ):
+        app.build()
+
+    html = (app.outdir / "index.html").read_text()
+    assert EXPECTED in html

--- a/tests/ext/lastmodified_test.py
+++ b/tests/ext/lastmodified_test.py
@@ -12,6 +12,8 @@ from sphinx.testing.util import SphinxTestApp
 
 FIXED_DATE = datetime(2024, 6, 1, tzinfo=UTC)
 EXPECTED = "Jun 01, 2024"
+# The ISO 8601 form of FIXED_DATE, as emitted into the page metadata.
+EXPECTED_ISO = "2024-06-01T00:00:00+00:00"
 
 # Whether pydata-sphinx-theme is importable. The end-to-end render test must
 # be skipped *before* the ``app`` fixture is built, because building with
@@ -33,20 +35,30 @@ def _build_and_capture(
 ) -> dict[str, dict]:
     """Build the app with GitRepository mocked, capturing each page's context.
 
-    The probe handler is connected after the extension's handler, so it
-    observes the ``last_updated`` value that the extension set (if any).
+    The probe handler is connected at a higher priority than the extension's
+    handler (which runs at priority 600), so it observes the ``last_updated``
+    value and ``metatags`` that the extension set (if any).
     """
     captured: dict[str, dict] = {}
 
     def probe(app, pagename, templatename, context, doctree):
         captured[pagename] = dict(context)
 
-    app.connect("html-page-context", probe)
+    app.connect("html-page-context", probe, priority=700)
     with patch(
         "documenteer.ext.lastmodified.GitRepository", return_value=mock_repo
     ):
         app.build()
     return captured
+
+
+def _has_modified_metatags(context: dict) -> bool:
+    """Whether a captured context carries any last-modified metadata.
+
+    The extension only ever emits these tags together, so the Open Graph tag
+    is a sufficient sentinel for the whole set.
+    """
+    return "article:modified_time" in context.get("metatags", "")
 
 
 @pytest.mark.sphinx(
@@ -71,6 +83,31 @@ def test_last_updated_on_content_pages(app: SphinxTestApp) -> None:
 
 
 @pytest.mark.sphinx(
+    "html", testroot="lastmodified", srcdir="lastmodified-metatags"
+)
+def test_last_modified_metatags_on_content_pages(app: SphinxTestApp) -> None:
+    """Content pages emit Open Graph, Dublin Core, and JSON-LD metadata.
+
+    All three signals carry the same ISO 8601 Git commit date, making the
+    extension the single source of truth for the page's last-modified date.
+    """
+    mock_repo = _mock_git_repository()
+    captured = _build_and_capture(app, mock_repo)
+
+    metatags = captured["index"]["metatags"]
+    assert (
+        f'<meta property="article:modified_time" content="{EXPECTED_ISO}" />'
+        in metatags
+    )
+    assert (
+        f'<meta name="dcterms.modified" content="{EXPECTED_ISO}" />'
+        in metatags
+    )
+    assert '<script type="application/ld+json">' in metatags
+    assert f'"dateModified": "{EXPECTED_ISO}"' in metatags
+
+
+@pytest.mark.sphinx(
     "html", testroot="lastmodified", srcdir="lastmodified-special"
 )
 def test_last_updated_none_on_special_pages(app: SphinxTestApp) -> None:
@@ -86,6 +123,10 @@ def test_last_updated_none_on_special_pages(app: SphinxTestApp) -> None:
 
     assert captured["genindex"]["last_updated"] is None
     assert captured["search"]["last_updated"] is None
+
+    # Sourceless pages also get no last-modified metadata.
+    assert not _has_modified_metatags(captured["genindex"])
+    assert not _has_modified_metatags(captured["search"])
 
 
 @pytest.mark.sphinx(
@@ -107,6 +148,10 @@ def test_last_updated_disabled(app: SphinxTestApp) -> None:
     assert captured["page2"]["last_updated"] is None
     mock_repo.compute_last_modified.assert_not_called()
 
+    # No last-modified metadata is emitted when the feature is disabled.
+    assert not _has_modified_metatags(captured["index"])
+    assert not _has_modified_metatags(captured["page2"])
+
 
 @pytest.mark.sphinx(
     "html", testroot="lastmodified", srcdir="lastmodified-shallow"
@@ -125,6 +170,10 @@ def test_last_updated_suppressed_for_shallow_clone(app: SphinxTestApp) -> None:
     assert captured["index"]["last_updated"] is None
     assert captured["page2"]["last_updated"] is None
     mock_repo.compute_last_modified.assert_not_called()
+
+    # Misleading metadata is suppressed along with the visible timestamp.
+    assert not _has_modified_metatags(captured["index"])
+    assert not _has_modified_metatags(captured["page2"])
 
     # The user is warned exactly once about the shallow clone.
     warnings = app.warning.getvalue()
@@ -154,3 +203,8 @@ def test_last_updated_rendered_in_pydata_article(app: SphinxTestApp) -> None:
 
     html = (app.outdir / "index.html").read_text()
     assert EXPECTED in html
+    # The machine-readable Open Graph tag is rendered into the page <head>.
+    assert (
+        f'<meta property="article:modified_time" content="{EXPECTED_ISO}" />'
+        in html
+    )

--- a/tests/ext/lastmodified_test.py
+++ b/tests/ext/lastmodified_test.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import importlib.util
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -15,6 +15,14 @@ EXPECTED = "Jun 01, 2024"
 # The ISO 8601 form of FIXED_DATE, as emitted into the page metadata.
 EXPECTED_ISO = "2024-06-01T00:00:00+00:00"
 
+# A commit datetime in a non-UTC offset that also crosses a day boundary when
+# normalized to UTC: 22:00 on Jun 01 at -07:00 is 05:00 on Jun 02 in UTC.
+OFFSET_DATE = datetime(2024, 6, 1, 22, 0, tzinfo=timezone(timedelta(hours=-7)))
+# The footer date keeps the commit's own offset (still Jun 01 locally).
+OFFSET_EXPECTED = "Jun 01, 2024"
+# The head metadata is normalized to UTC, shifting to the next day.
+OFFSET_EXPECTED_ISO = "2024-06-02T05:00:00+00:00"
+
 # Whether pydata-sphinx-theme is importable. The end-to-end render test must
 # be skipped *before* the ``app`` fixture is built, because building with
 # ``html_theme = "pydata_sphinx_theme"`` would otherwise error during fixture
@@ -22,11 +30,11 @@ EXPECTED_ISO = "2024-06-01T00:00:00+00:00"
 _HAS_PYDATA = importlib.util.find_spec("pydata_sphinx_theme") is not None
 
 
-def _mock_git_repository() -> MagicMock:
+def _mock_git_repository(date: datetime = FIXED_DATE) -> MagicMock:
     """Build a mock GitRepository that always reports a fixed commit date."""
     mock_repo = MagicMock()
     mock_repo.is_shallow = False
-    mock_repo.compute_last_modified.return_value = FIXED_DATE
+    mock_repo.compute_last_modified.return_value = date
     return mock_repo
 
 
@@ -105,6 +113,37 @@ def test_last_modified_metatags_on_content_pages(app: SphinxTestApp) -> None:
     )
     assert '<script type="application/ld+json">' in metatags
     assert f'"dateModified": "{EXPECTED_ISO}"' in metatags
+
+
+@pytest.mark.sphinx(
+    "html", testroot="lastmodified", srcdir="lastmodified-metatags-utc"
+)
+def test_last_modified_metatags_utc_normalized(app: SphinxTestApp) -> None:
+    """Head metadata is normalized to UTC; the footer keeps the commit offset.
+
+    A commit recorded at a non-UTC offset (here ``-07:00``) is emitted into the
+    HTML ``<head>`` as a UTC (``+00:00``) ISO 8601 string, so the machine
+    signals are contributor-independent. Because this commit's local time is
+    late in the day, the UTC value rolls over to the next day -- yet the
+    human-readable footer date stays on the commit's own (earlier) day.
+    """
+    mock_repo = _mock_git_repository(OFFSET_DATE)
+    captured = _build_and_capture(app, mock_repo)
+
+    metatags = captured["index"]["metatags"]
+    assert (
+        f'<meta property="article:modified_time" '
+        f'content="{OFFSET_EXPECTED_ISO}" />' in metatags
+    )
+    assert (
+        f'<meta name="dcterms.modified" content="{OFFSET_EXPECTED_ISO}" />'
+        in metatags
+    )
+    assert f'"dateModified": "{OFFSET_EXPECTED_ISO}"' in metatags
+
+    # The visible footer date keeps the commit's own offset (the head-only
+    # scope of the UTC normalization).
+    assert captured["index"]["last_updated"] == OFFSET_EXPECTED
 
 
 @pytest.mark.sphinx(

--- a/tests/ext/lastmodified_test.py
+++ b/tests/ext/lastmodified_test.py
@@ -10,10 +10,14 @@ from unittest.mock import MagicMock, patch
 import pytest
 from sphinx.testing.util import SphinxTestApp
 
+from documenteer.conf._utils import get_template_dir
+
 FIXED_DATE = datetime(2024, 6, 1, tzinfo=UTC)
 EXPECTED = "Jun 01, 2024"
 # The ISO 8601 form of FIXED_DATE, as emitted into the page metadata.
 EXPECTED_ISO = "2024-06-01T00:00:00+00:00"
+# The UTC date as YYYY-MM-DD, the no-JavaScript visible footer fallback.
+EXPECTED_DATE = "2024-06-01"
 
 # A commit datetime in a non-UTC offset that also crosses a day boundary when
 # normalized to UTC: 22:00 on Jun 01 at -07:00 is 05:00 on Jun 02 in UTC.
@@ -28,6 +32,12 @@ OFFSET_EXPECTED_ISO = "2024-06-02T05:00:00+00:00"
 # ``html_theme = "pydata_sphinx_theme"`` would otherwise error during fixture
 # setup when the theme isn't installed.
 _HAS_PYDATA = importlib.util.find_spec("pydata_sphinx_theme") is not None
+# Whether sphinx-last-updated-by-git is importable. The user-guide preset
+# auto-loads it through sphinx-sitemap; the guide-stack regression test loads
+# it explicitly to reproduce the footer/last_updated interaction.
+_HAS_GIT_EXT = (
+    importlib.util.find_spec("sphinx_last_updated_by_git") is not None
+)
 
 
 def _mock_git_repository(date: datetime = FIXED_DATE) -> MagicMock:
@@ -91,6 +101,24 @@ def test_last_updated_on_content_pages(app: SphinxTestApp) -> None:
 
 
 @pytest.mark.sphinx(
+    "html", testroot="lastmodified", srcdir="lastmodified-timecontext"
+)
+def test_last_modified_time_context_vars(app: SphinxTestApp) -> None:
+    """Content pages expose the UTC ISO and date context vars.
+
+    These feed the ``<time>`` element rendered by the overridden
+    ``last-updated`` component: the ISO value populates the ``datetime``
+    attribute and the ``YYYY-MM-DD`` date is the no-JavaScript visible
+    fallback.
+    """
+    mock_repo = _mock_git_repository()
+    captured = _build_and_capture(app, mock_repo)
+
+    assert captured["index"]["documenteer_last_modified_iso"] == EXPECTED_ISO
+    assert captured["index"]["documenteer_last_modified_date"] == EXPECTED_DATE
+
+
+@pytest.mark.sphinx(
     "html", testroot="lastmodified", srcdir="lastmodified-metatags"
 )
 def test_last_modified_metatags_on_content_pages(app: SphinxTestApp) -> None:
@@ -144,6 +172,14 @@ def test_last_modified_metatags_utc_normalized(app: SphinxTestApp) -> None:
     # The visible footer date keeps the commit's own offset (the head-only
     # scope of the UTC normalization).
     assert captured["index"]["last_updated"] == OFFSET_EXPECTED
+
+    # The <time> context vars track UTC, so they roll over to the next day
+    # while ``last_updated`` stays on the commit's earlier day.
+    assert (
+        captured["index"]["documenteer_last_modified_iso"]
+        == OFFSET_EXPECTED_ISO
+    )
+    assert captured["index"]["documenteer_last_modified_date"] == "2024-06-02"
 
 
 @pytest.mark.sphinx(
@@ -230,10 +266,16 @@ def test_last_updated_suppressed_for_shallow_clone(app: SphinxTestApp) -> None:
     confoverrides={
         "html_theme": "pydata_sphinx_theme",
         "html_theme_options": {"article_footer_items": ["last-updated"]},
+        "templates_path": [get_template_dir("pydata")],
     },
 )
 def test_last_updated_rendered_in_pydata_article(app: SphinxTestApp) -> None:
-    """End-to-end: the date appears at the bottom of the rendered article."""
+    """End-to-end: the date appears at the bottom of the rendered article.
+
+    Documenteer's pydata templates are added to the build so the overriding
+    ``last-updated.html`` component (which renders the ``<time>`` element) is
+    exercised.
+    """
     mock_repo = _mock_git_repository()
     with patch(
         "documenteer.ext.lastmodified.GitRepository", return_value=mock_repo
@@ -241,9 +283,65 @@ def test_last_updated_rendered_in_pydata_article(app: SphinxTestApp) -> None:
         app.build()
 
     html = (app.outdir / "index.html").read_text()
-    assert EXPECTED in html
+    # The overriding component renders the page-level wording and the <time>
+    # element: the UTC ISO in the datetime attribute and the YYYY-MM-DD UTC
+    # fallback as the visible text.
+    assert "This page was last modified on" in html
+    assert f'<time datetime="{EXPECTED_ISO}"' in html
+    assert f">{EXPECTED_DATE}</time>" in html
     # The machine-readable Open Graph tag is rendered into the page <head>.
     assert (
         f'<meta property="article:modified_time" content="{EXPECTED_ISO}" />'
         in html
     )
+
+
+@pytest.mark.skipif(
+    not (_HAS_PYDATA and _HAS_GIT_EXT),
+    reason="pydata_sphinx_theme and sphinx_last_updated_by_git are required",
+)
+@pytest.mark.sphinx(
+    "html",
+    testroot="lastmodified",
+    srcdir="lastmodified-guidestack",
+    confoverrides={
+        "extensions": [
+            "sphinx_last_updated_by_git",
+            "documenteer.ext.lastmodified",
+        ],
+        "html_theme": "pydata_sphinx_theme",
+        "html_theme_options": {"article_footer_items": ["last-updated"]},
+        "templates_path": [get_template_dir("pydata")],
+        # Mirror the user-guide preset, which silences git-ext's duplicate tag.
+        "git_last_updated_metatags": False,
+    },
+)
+def test_last_updated_rendered_with_git_extension(app: SphinxTestApp) -> None:
+    """End-to-end with sphinx-last-updated-by-git loaded, as in the guide.
+
+    The guide preset auto-loads sphinx-last-updated-by-git (through
+    sphinx-sitemap). Its html-page-context handler resets ``last_updated`` to
+    `None` (``html_last_updated_fmt`` is unset). This regression test pins the
+    handler priority bracketing: the ``<time>`` footer component still survives
+    pydata's empty-check (so the footer renders) and the late handler still
+    restores ``last_updated`` (so the ``docbuild:last-update`` tag is emitted).
+    """
+    mock_repo = _mock_git_repository()
+    with patch(
+        "documenteer.ext.lastmodified.GitRepository", return_value=mock_repo
+    ):
+        app.build()
+
+    html = (app.outdir / "index.html").read_text()
+    # The footer component renders despite git-ext clearing last_updated.
+    assert "This page was last modified on" in html
+    assert f'<time datetime="{EXPECTED_ISO}"' in html
+    # The late handler wins last_updated, so pydata's meta tag carries it.
+    assert f'<meta name="docbuild:last-update" content="{EXPECTED}"' in html
+    # Documenteer remains the single source of the Open Graph tag (git-ext's
+    # duplicate is silenced).
+    assert (
+        f'<meta property="article:modified_time" content="{EXPECTED_ISO}" />'
+        in html
+    )
+    assert html.count('property="article:modified_time"') == 1

--- a/tests/roots/test-lastmodified/conf.py
+++ b/tests/roots/test-lastmodified/conf.py
@@ -1,0 +1,8 @@
+# Basic Sphinx configuration for testing the lastmodified extension
+extensions = [
+    "documenteer.ext.lastmodified",
+]
+
+project = "Last Modified Test"
+html_theme = "basic"
+exclude_patterns = ["_build"]

--- a/tests/roots/test-lastmodified/index.rst
+++ b/tests/roots/test-lastmodified/index.rst
@@ -1,0 +1,12 @@
+#################
+Last Modified Test
+#################
+
+This is a test site for the lastmodified extension.
+
+.. literalinclude:: snippet.txt
+
+.. toctree::
+   :maxdepth: 2
+
+   page2

--- a/tests/roots/test-lastmodified/page2.rst
+++ b/tests/roots/test-lastmodified/page2.rst
@@ -1,0 +1,5 @@
+######
+Page 2
+######
+
+A second content page with no includes.

--- a/tests/roots/test-lastmodified/snippet.txt
+++ b/tests/roots/test-lastmodified/snippet.txt
@@ -1,0 +1,1 @@
+This snippet is pulled into index.rst via literalinclude.

--- a/tests/test_conf_toml.py
+++ b/tests/test_conf_toml.py
@@ -76,6 +76,23 @@ disable_primary_sidebars = [
 ]
 """
 
+EXAMPLE_NO_LAST_UPDATED = """
+
+[project]
+title = "Documenteer"
+copyright = "2022 AURA"
+
+[sphinx.theme]
+show_last_updated = false
+"""
+
+EXAMPLE_NO_SPHINX = """
+
+[project]
+title = "Documenteer"
+copyright = "2022 AURA"
+"""
+
 
 def test_load() -> None:
     config = DocumenteerConfig.load(EXAMPLE)
@@ -162,3 +179,16 @@ def test_disable_primary_sidebars() -> None:
     html_sidebars: dict[str, list[str]] = {}
     config.disable_primary_sidebars(html_sidebars)
     assert html_sidebars == {"index": [], "changelog": []}
+
+
+def test_show_last_updated_default() -> None:
+    """show_last_updated defaults to True when not configured."""
+    assert DocumenteerConfig.load(EXAMPLE).show_last_updated is True
+    # Also defaults to True when there's no [sphinx] table at all.
+    assert DocumenteerConfig.load(EXAMPLE_NO_SPHINX).show_last_updated is True
+
+
+def test_show_last_updated_disabled() -> None:
+    """show_last_updated reflects sphinx.theme.show_last_updated = false."""
+    config = DocumenteerConfig.load(EXAMPLE_NO_LAST_UPDATED)
+    assert config.show_last_updated is False

--- a/tests/test_git_repository.py
+++ b/tests/test_git_repository.py
@@ -1,0 +1,125 @@
+"""Tests for documenteer.conf._utils.GitRepository.compute_last_modified."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from git import Actor, Repo
+
+from documenteer.conf._utils import GitRepository
+
+ACTOR = Actor("Test Author", "test@example.com")
+
+
+def _commit(repo: Repo, paths: list[Path], message: str, date: str) -> None:
+    """Stage ``paths`` and commit them at a fixed author/committer date.
+
+    ``date`` is an ISO 8601 string understood by Git, e.g.
+    ``"2024-06-01T00:00:00+0000"``.
+    """
+    repo.index.add([str(p) for p in paths])
+    repo.index.commit(
+        message,
+        author=ACTOR,
+        committer=ACTOR,
+        author_date=date,
+        commit_date=date,
+    )
+
+
+def test_source_only(tmp_path: Path) -> None:
+    """The last-modified date for a single tracked file is its commit date."""
+    repo = Repo.init(tmp_path)
+    page = tmp_path / "index.rst"
+    page.write_text("Page\n")
+    _commit(repo, [page], "Add page", "2024-06-01T00:00:00+0000")
+
+    git_repo = GitRepository(tmp_path)
+    result = git_repo.compute_last_modified([page])
+    assert result == datetime(2024, 6, 1, tzinfo=UTC)
+
+
+def test_max_of_source_and_include(tmp_path: Path) -> None:
+    """The date is the most-recent commit across the source and its
+    dependencies (the includes behavior).
+    """
+    repo = Repo.init(tmp_path)
+    page = tmp_path / "index.rst"
+    page.write_text("Page\n")
+    _commit(repo, [page], "Add page", "2024-06-01T00:00:00+0000")
+
+    snippet = tmp_path / "snippet.txt"
+    snippet.write_text("snippet\n")
+    _commit(repo, [snippet], "Add snippet", "2024-07-15T00:00:00+0000")
+
+    git_repo = GitRepository(tmp_path)
+
+    # Source alone reflects only its own commit.
+    assert git_repo.compute_last_modified([page]) == datetime(
+        2024, 6, 1, tzinfo=UTC
+    )
+
+    # Source + later-modified include reflects the include's newer commit.
+    assert git_repo.compute_last_modified([page, snippet]) == datetime(
+        2024, 7, 15, tzinfo=UTC
+    )
+
+
+def test_uncommitted_file_skipped(tmp_path: Path) -> None:
+    """Untracked/uncommitted files are skipped; with no tracked paths the
+    result is None.
+    """
+    repo = Repo.init(tmp_path)
+    page = tmp_path / "index.rst"
+    page.write_text("Page\n")
+    _commit(repo, [page], "Add page", "2024-06-01T00:00:00+0000")
+
+    new_file = tmp_path / "draft.rst"
+    new_file.write_text("Draft\n")  # written but never committed
+
+    git_repo = GitRepository(tmp_path)
+
+    # The uncommitted file alone yields None.
+    assert git_repo.compute_last_modified([new_file]) is None
+
+    # The uncommitted file is ignored when mixed with a tracked file.
+    assert git_repo.compute_last_modified([page, new_file]) == datetime(
+        2024, 6, 1, tzinfo=UTC
+    )
+
+
+def test_path_outside_working_tree_skipped(tmp_path: Path) -> None:
+    """Paths outside the Git working tree are ignored defensively."""
+    repo = Repo.init(tmp_path)
+    page = tmp_path / "index.rst"
+    page.write_text("Page\n")
+    _commit(repo, [page], "Add page", "2024-06-01T00:00:00+0000")
+
+    outside = tmp_path.parent / "outside.txt"
+
+    git_repo = GitRepository(tmp_path)
+    assert git_repo.compute_last_modified([outside]) is None
+    assert git_repo.compute_last_modified([page, outside]) == datetime(
+        2024, 6, 1, tzinfo=UTC
+    )
+
+
+def test_cache_reuse(tmp_path: Path) -> None:
+    """Per-path results are cached so shared dependencies resolve once."""
+    repo = Repo.init(tmp_path)
+    page = tmp_path / "index.rst"
+    page.write_text("Page\n")
+    _commit(repo, [page], "Add page", "2024-06-01T00:00:00+0000")
+
+    git_repo = GitRepository(tmp_path)
+    assert not git_repo._last_modified_cache
+
+    first = git_repo.compute_last_modified([page])
+    key = str(page.resolve())
+    assert key in git_repo._last_modified_cache
+    assert git_repo._last_modified_cache[key] == first
+
+    # A second call returns the same cached value.
+    second = git_repo.compute_last_modified([page])
+    assert second == first


### PR DESCRIPTION
## Summary

- Add a `documenteer.ext.lastmodified` Sphinx extension that derives a "Last updated on <date>." footer for every user guide page from the page's **Git commit history**, not filesystem mtime (which is meaningless in CI).
- The date is the most-recent commit across the page's own source **and** any files it pulls in via `include`/`literalinclude`, so editing an included snippet advances every page that uses it (resolving the ticket's caveat).
- Reuses pydata-sphinx-theme's built-in `last-updated` footer component. On by default; disable with `show_last_updated = false` in the `[sphinx.theme]` table of `documenteer.toml`.
- Detects a **shallow clone** (whose truncated history would otherwise collapse every page to the boundary commit's date) and omits the timestamp site-wide with a single build warning, rather than publishing misleading dates. CI must check out full history (`fetch-depth: 0`).

## Validation steps

- Build a guide that uses `documenteer.conf.guide` and confirm a built page footer shows "Last updated on <date>." matching `git log -1 --format=%cd -- <source-file>`.
- Touch-and-commit a file that a page `include`s/`literalinclude`s, rebuild, and confirm that page's date advances.
- Set `[sphinx.theme] show_last_updated = false`, rebuild, and confirm the footer timestamp disappears.
- In a shallow checkout (`actions/checkout` default), confirm no page shows a date and a "shallow clone" warning is emitted; with `fetch-depth: 0` confirm dates appear.
- Confirm `genindex`/`search` build without a footer date and without errors.

## References

- Jira: https://rubinobs.atlassian.net/browse/DM-53811