### PR TITLE
DM-55230: Fix periodic CI by declaring py-test-sphinxdev

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,13 @@ deps =
 commands=
     coverage run -m pytest {posargs}
 
+[testenv:py-test-sphinx{7,8,dev}]
+description =
+    Run pytest
+    sphinx7: with sphinx 7.*
+    sphinx8: with sphinx 8.*
+    sphinxdev: with sphinx master branch
+
 [testenv:coverage-report]
 description = Compile coverage from each test run.
 skip_install = true


### PR DESCRIPTION
## Summary

- The periodic CI (`Periodic CI` / `ci-cron.yaml`) test matrix includes a `dev` Sphinx row, which invokes `run-tox` with the env set `typing-sphinxdev,py-test-sphinxdev,demo`. Only `typing-sphinxdev` (via the generative `[testenv:typing-sphinx{7,8,dev}]` section) and `demo` were declared; the test envs existed solely as the concrete envlist entries `py-test-sphinx7`/`py-test-sphinx8`, with no generative section carrying a `dev` factor.
- tox 4 refuses to run any environment it cannot find in configuration, so the periodic run aborted with a `HandledError` (exit 254) before executing anything.
- Adds a generative `[testenv:py-test-sphinx{7,8,dev}]` section mirroring the existing `typing` pattern. It inherits the pytest command and the `sphinxdev:` Sphinx-master dependency from `[testenv]`, so `py-test-sphinxdev` now resolves without pulling Sphinx master into the default local `tox` run (it appears as an "additional environment," not a default one).

## Validation steps

- `uvx --with tox-uv tox list` shows `py-test-sphinxdev` under "additional environments".
- `uvx --with tox-uv tox run -e typing-sphinxdev,py-test-sphinxdev,demo --notest` resolves and provisions all three environments (previously errored with exit 254).
- Confirm the next `Periodic CI` run (or a manual `workflow_dispatch`) gets past env resolution for the `dev` matrix row.

## References

- Jira: https://rubinobs.atlassian.net/browse/DM-55230