### PR TITLE
DM-55292: Fix devcontainer build and npm GitHub Packages auth

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,9 +4,14 @@
 # sandbox build are identical.
 FROM mcr.microsoft.com/devcontainers/python:1-3.13-bookworm
 
+# The Microsoft base image ships a Yarn apt source whose signing key has
+# rotated, so `apt-get update` aborts on it (NO_PUBKEY 62D54FD4003F6525). We
+# use npm, not Yarn, so drop the source before updating.
+#
 # graphviz provides `dot`, used by sphinx-diagrams when building the docs and
 # demo technotes (docs/guides/diagrams.rst, demo/rst-technote/diagram.py).
-RUN apt-get update \
+RUN rm -f /etc/apt/sources.list.d/yarn.list \
+    && apt-get update \
     && export DEBIAN_FRONTEND=noninteractive \
     && apt-get install -y --no-install-recommends graphviz \
     && apt-get clean \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,14 +8,23 @@
     // Pinned to 18 to match .nvmrc.
     "ghcr.io/devcontainers/features/node:1": { "version": "18" }
   },
+  // Classic PAT with the read:packages scope, mapped from the host env so npm
+  // can authenticate to GitHub Packages (see postCreateCommand). Kept separate
+  // from GH_TOKEN because npm.pkg.github.com only accepts classic PATs and
+  // rejects the fine-grained token GH_TOKEN carries.
+  "containerEnv": {
+    "NPM_PKG_TOKEN": "${localEnv:NPM_PKG_TOKEN}"
+  },
   // 1. uv sync --all-extras == `.[technote,guide]` + the dev group
   //    (test/typing/docs), matching `make init`.
-  // 2. Map the GH_TOKEN secret into ~/.npmrc so npm can read
+  // 2. Map the NPM_PKG_TOKEN secret into ~/.npmrc so npm can read
   //    @lsst-sqre/rubin-style-dictionary from GitHub Packages (.npmrc points
-  //    @lsst-sqre at npm.pkg.github.com). Guarded so a missing token doesn't
-  //    write a broken auth line.
+  //    @lsst-sqre at npm.pkg.github.com). Must be a classic PAT with
+  //    read:packages — npm.pkg.github.com rejects fine-grained tokens — so it
+  //    stays separate from GH_TOKEN. Guarded so a missing token doesn't write
+  //    a broken auth line.
   // 3. Build the Rubin CSS/JS assets via webpack.
-  "postCreateCommand": "uv sync --all-extras && if [ -n \"$GH_TOKEN\" ]; then echo \"//npm.pkg.github.com/:_authToken=$GH_TOKEN\" >> ~/.npmrc; fi && npm install && npm run build",
+  "postCreateCommand": "uv sync --all-extras && if [ -n \"$NPM_PKG_TOKEN\" ]; then echo \"//npm.pkg.github.com/:_authToken=$NPM_PKG_TOKEN\" >> ~/.npmrc; fi && npm install && npm run build",
   "customizations": {
     "vscode": {
       "extensions": ["ms-python.python", "charliermarsh.ruff"]

--- a/.devcontainer/stoker/devcontainer.json
+++ b/.devcontainer/stoker/devcontainer.json
@@ -1,4 +1,4 @@
-// stoker-managed: sandbox:stoker/devcontainer.json:c087d2d1d2ce5881
+// stoker-managed: sandbox:stoker/devcontainer.json:71e2dc816acf2946
 {
   "name": "stoker-default-lsst-sqre-documenteer",
   "build": {
@@ -22,6 +22,7 @@
     "source=stoker-codex-lsst-sqre-documenteer,target=/home/vscode/.codex,type=volume"
   ],
   "containerEnv": {
+    "NPM_PKG_TOKEN": "${localEnv:NPM_PKG_TOKEN}",
     "STOKER_REPO_OWNER": "lsst-sqre",
     "STOKER_REPO_NAME": "documenteer",
     "STOKER_SECRETS_BACKEND": "op",
@@ -31,6 +32,6 @@
   },
   "remoteUser": "vscode",
   "onCreateCommand": "if { [ -n \"${CODESPACES:-}\" ] || [ -n \"${REMOTE_CONTAINERS:-}\" ]; } && [ -z \"${STOKER_SANDBOX:-}\" ]; then echo 'stoker: refusing to run the derived sandbox onCreate under Codespaces/VS Code \u2014 it clones the repo over a volume and is meant for `stoker run` / `stoker sandbox`. Open .devcontainer/devcontainer.json for local development, or set STOKER_SANDBOX=1 to override.' >&2; exit 1; fi && sudo chown \"$(id -u):$(id -g)\" /workspace && if [ -d /workspace/.git ]; then echo \"Workspace already seeded; skipping clone\"; elif [ -n \"$(ls -A /workspace 2>/dev/null)\" ]; then echo '/workspace is non-empty but has no .git; refusing to clone over it \u2014 run `stoker sandbox rebuild` to re-seed' >&2; exit 1; else if [ -z \"${GH_TOKEN}\" ]; then echo 'GH_TOKEN is unset; cannot seed /workspace' >&2; exit 1; fi; echo \"Seeding /workspace from ${STOKER_CLONE_BRANCH:-<remote default>}\"; git clone ${STOKER_CLONE_BRANCH:+--branch \"${STOKER_CLONE_BRANCH}\"} \"https://x-access-token:${GH_TOKEN}@github.com/${STOKER_REPO_OWNER}/${STOKER_REPO_NAME}.git\" /workspace; git -C /workspace remote set-url origin \"https://github.com/${STOKER_REPO_OWNER}/${STOKER_REPO_NAME}.git\"; fi && if [ -n \"${GH_TOKEN}\" ]; then git config --global credential.helper '!f() { echo username=x-access-token; echo password=${GH_TOKEN}; }; f'; fi",
-  "postCreateCommand": "sudo chown -R vscode:vscode /home/vscode/.claude /home/vscode/.codex && { [ -f /home/vscode/.codex/config.toml ] || install -m 0644 .devcontainer/stoker/codex-config.toml /home/vscode/.codex/config.toml; } && sudo .devcontainer/stoker/init-firewall.sh && sudo install -m 0644 -o root -g root .devcontainer/stoker/firewall-refresh.cron /etc/cron.d/stoker-firewall-refresh && sudo touch /var/log/stoker-firewall.log && sudo chmod 0640 /var/log/stoker-firewall.log && sudo service cron start && npm install -g @anthropic-ai/claude-code @openai/codex @github/copilot && uv sync --all-extras && if [ -n \"$GH_TOKEN\" ]; then echo \"//npm.pkg.github.com/:_authToken=$GH_TOKEN\" >> ~/.npmrc; fi && npm install && npm run build",
+  "postCreateCommand": "sudo chown -R vscode:vscode /home/vscode/.claude /home/vscode/.codex && { [ -f /home/vscode/.codex/config.toml ] || install -m 0644 .devcontainer/stoker/codex-config.toml /home/vscode/.codex/config.toml; } && sudo .devcontainer/stoker/init-firewall.sh && sudo install -m 0644 -o root -g root .devcontainer/stoker/firewall-refresh.cron /etc/cron.d/stoker-firewall-refresh && sudo touch /var/log/stoker-firewall.log && sudo chmod 0640 /var/log/stoker-firewall.log && sudo service cron start && npm install -g @anthropic-ai/claude-code @openai/codex @github/copilot && uv sync --all-extras && if [ -n \"$NPM_PKG_TOKEN\" ]; then echo \"//npm.pkg.github.com/:_authToken=$NPM_PKG_TOKEN\" >> ~/.npmrc; fi && npm install && npm run build",
   "postStartCommand": "sudo service cron start"
 }

--- a/.stoker/settings.toml
+++ b/.stoker/settings.toml
@@ -3,3 +3,17 @@ source = "github.com/lsst-sqre/rubin-stoker//profile@main"
 
 [sandbox]
 repo = "lsst-sqre/documenteer"
+
+[sandbox.env]
+# Classic GitHub PAT (read:packages) for npm auth to GitHub Packages. The
+# derived devcontainer's containerEnv maps ${localEnv:NPM_PKG_TOKEN}, so stoker
+# surfaces this at bring-up to postCreateCommand's `npm install` (which fetches
+# the private @lsst-sqre/rubin-style-dictionary) as well as to exec-time agent
+# commands. Resolved from the npm_pkg_token secret binding.
+NPM_PKG_TOKEN = "$secret:npm_pkg_token"
+
+[secrets_required.npm_pkg_token]
+description = "Classic GitHub PAT with the read:packages scope for npm auth to GitHub Packages; npm.pkg.github.com rejects fine-grained tokens, so this is separate from gh_token"
+example = "op://Private/GitHub Packages Read/credential"
+optional = false
+format = "string"

--- a/docs/dev/development.rst
+++ b/docs/dev/development.rst
@@ -31,6 +31,9 @@ To develop Documenteer, create a virtual environment with your method of choice 
    cd documenteer
    make init
 
+A complete environment also needs the compiled web assets (see :doc:`theme-assets`).
+Because the asset build pulls the private ``@lsst-sqre/rubin-style-dictionary`` package from GitHub Packages, you must first :ref:`authenticate npm to GitHub Packages <theme-assets-github-packages>` with a classic ``read:packages`` personal access token.
+
 .. _dev-pre-commit:
 
 Code formatting and linting with pre-commit

--- a/docs/dev/theme-assets.rst
+++ b/docs/dev/theme-assets.rst
@@ -10,6 +10,28 @@ Webpack compiles and installs these assets into the Documenteer package at ``src
 These compiled assets are not committed in Git, but *are* included in the Python package via ``MANIFEST.in``.
 Therefore the webpack build step (``npm run build``) *must* be run in any development and CI environment.
 
+.. _theme-assets-github-packages:
+
+Authenticating npm to GitHub Packages
+=====================================
+
+Documenteer's npm dependencies include the private ``@lsst-sqre/rubin-style-dictionary`` package, which is published to GitHub Packages rather than the public npm registry.
+The repository's ``.npmrc`` points the ``@lsst-sqre`` scope at ``https://npm.pkg.github.com/``, so ``npm install`` must authenticate to GitHub Packages before it can download that package.
+
+GitHub Packages' npm registry **only accepts a classic personal access token (PAT)**; fine-grained tokens are rejected with a ``403`` ``permission_denied`` ("token does not match expected scopes") error.
+Create a classic PAT with **only** the ``read:packages`` scope at https://github.com/settings/tokens, and — because ``lsst-sqre`` enforces SAML single sign-on — authorize the token for the ``lsst-sqre`` organization.
+
+To build the assets outside a dev container, add the token to your user ``~/.npmrc``:
+
+.. code-block:: ini
+
+   //npm.pkg.github.com/:_authToken=<your classic read:packages PAT>
+
+The dev container and GitHub Codespaces configurations instead read the token from a ``NPM_PKG_TOKEN`` environment variable and write that same ``~/.npmrc`` line automatically during ``postCreateCommand``.
+In a Codespace, provide the token as a `Codespaces secret`_ named ``NPM_PKG_TOKEN``; the token that Codespaces provisions automatically is scoped to this repository and cannot read a package published from another repository.
+
+.. _Codespaces secret: https://docs.github.com/en/codespaces/managing-your-codespaces/managing-your-account-specific-secrets-for-github-codespaces
+
 .. Source assets:
 .. src/assets
 .. node_modules/@lsst-sqre/rubin-style-dictionary/assets

--- a/docs/dev/theme-assets.rst
+++ b/docs/dev/theme-assets.rst
@@ -21,14 +21,39 @@ The repository's ``.npmrc`` points the ``@lsst-sqre`` scope at ``https://npm.pkg
 GitHub Packages' npm registry **only accepts a classic personal access token (PAT)**; fine-grained tokens are rejected with a ``403`` ``permission_denied`` ("token does not match expected scopes") error.
 Create a classic PAT with **only** the ``read:packages`` scope at https://github.com/settings/tokens, and — because ``lsst-sqre`` enforces SAML single sign-on — authorize the token for the ``lsst-sqre`` organization.
 
-To build the assets outside a dev container, add the token to your user ``~/.npmrc``:
+Outside a dev container
+-----------------------
+
+To build the assets directly on your machine, add the token to your user ``~/.npmrc``:
 
 .. code-block:: ini
 
    //npm.pkg.github.com/:_authToken=<your classic read:packages PAT>
 
 The dev container and GitHub Codespaces configurations instead read the token from a ``NPM_PKG_TOKEN`` environment variable and write that same ``~/.npmrc`` line automatically during ``postCreateCommand``.
-In a Codespace, provide the token as a `Codespaces secret`_ named ``NPM_PKG_TOKEN``; the token that Codespaces provisions automatically is scoped to this repository and cannot read a package published from another repository.
+A local (Docker Desktop) dev container inherits ``NPM_PKG_TOKEN`` from the shell that launches it, so export it before opening the container.
+
+In GitHub Codespaces
+--------------------
+
+Codespaces does not have access to your local environment, so it cannot inherit ``NPM_PKG_TOKEN`` from your shell.
+The token that Codespaces provisions automatically (``GITHUB_TOKEN``) can't be used either: it is scoped to this repository and cannot read ``@lsst-sqre/rubin-style-dictionary``, which is published from a different repository.
+
+Instead, provide the token as a **personal** (account-level) `Codespaces secret`_, so it is private to *your* codespaces and is not shared on the repository:
+
+#. Create a classic ``read:packages`` PAT as described above (authorized for ``lsst-sqre`` SSO).
+#. Go to https://github.com/settings/codespaces → :guilabel:`Codespaces secrets` → :guilabel:`New secret`.
+#. Name it ``NPM_PKG_TOKEN``, paste the token, and grant it access to the ``lsst-sqre/documenteer`` repository.
+
+Or, equivalently, with the GitHub CLI:
+
+.. code-block:: sh
+
+   gh secret set NPM_PKG_TOKEN --user --app codespaces --repos lsst-sqre/documenteer
+
+Each developer sets their own secret; nothing needs to be configured on the repository itself.
+The next codespace you create on this repository will pick up the token and authenticate ``npm install`` during ``postCreateCommand``.
+(An existing codespace needs to be rebuilt to pick up a newly-added secret.)
 
 .. _Codespaces secret: https://docs.github.com/en/codespaces/managing-your-codespaces/managing-your-account-specific-secrets-for-github-codespaces
 


### PR DESCRIPTION
## Summary

Two host-side fixes that let the dev container (and the stoker sandbox, which builds from the same `../Dockerfile`) build and start cleanly, plus the docs to match. All are filed here as standalone host-side changes because a devcontainer build/startup failure can't be repaired by the stoker AFK loop — the loop needs the container up first.

**1. Drop the stale Yarn apt source (build).** The `.devcontainer/Dockerfile` build failed at the `graphviz` install step:

```
W: GPG error: https://dl.yarnpkg.com/debian stable InRelease: ... NO_PUBKEY 62D54FD4003F6525
E: The repository 'https://dl.yarnpkg.com/debian stable InRelease' is not signed.
```

The Microsoft `devcontainers/python:1-3.13-bookworm` base image ships a Yarn apt source whose signing key has rotated, so `apt-get update` aborts on the unsigned repo (exit 100) before `graphviz` can install. The project uses npm, not Yarn, so this drops the stale Yarn apt source before `apt-get update` rather than re-importing its key.

**2. Authenticate npm to GitHub Packages with a classic PAT (startup).** The `postCreateCommand` runs `npm install`, which fetches the private `@lsst-sqre/rubin-style-dictionary` from GitHub Packages. `npm.pkg.github.com` only accepts classic PATs and rejects the fine-grained `GH_TOKEN`, so the install failed with `403 — token does not match expected scopes`, blocking the sandbox from coming up.

This adds a separate `NPM_PKG_TOKEN` — a classic `read:packages` PAT, kept distinct from the fine-grained `GH_TOKEN` used for git/gh — wired declaratively through stoker's `[sandbox.env]` so it reaches `postCreateCommand` at bring-up (and exec-time agent commands), resolved from a `npm_pkg_token` 1Password secret binding. The committed config (`.stoker/settings.toml` `[sandbox.env]` + `[secrets_required.npm_pkg_token]`) declares the requirement; each operator provides their own binding in the gitignored `.stoker/settings.local.toml` (surfaced by `stoker doctor`).

**3. Document the requirement (docs).** The development guide never mentioned npm auth, so a developer building assets outside the dev container (`npm run build`, per `docs/dev/theme-assets.rst`) would hit the same 403 with no guidance. Adds a "Authenticating npm to GitHub Packages" section to the theme-assets page (classic `read:packages` PAT, `~/.npmrc` auth line, Codespaces-secret note) and a cross-reference from the environment-setup section of the development guide.

## Validation steps

- `docker build -f .devcontainer/Dockerfile .devcontainer` — builds clean; `apt-get update` succeeds with no GPG error, `graphviz` and `uv` install.
- `stoker doctor` — passes, including `Sandbox env bring-up: ok NPM_PKG_TOKEN reaches postCreate (containerEnv references ${localEnv:NPM_PKG_TOKEN})`.
- `stoker sandbox rebuild` — the sandbox comes up; `postCreateCommand`'s `npm install && npm run build` completes with no 403.
- `sphinx-build -b html docs` — builds clean with no new warnings on the changed pages.

## References

- Part of PRD #293 (DM-55292) — tooling modernization. Filed as standalone host-side changes because a devcontainer build/startup failure can't be repaired by the stoker AFK loop (the loop needs the container to build and start first).
- Depends on jsickcodes/stoker#230 — surfaces `[sandbox.env]` at container bring-up so `postCreateCommand` can consume secrets.
- Jira: https://rubinobs.atlassian.net/browse/DM-55292

Refs #293