### PR TITLE
DM-55292: Set package.json name to documenteer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "documenteer",
   "private": true,
   "scripts": {
     "build": "webpack"


### PR DESCRIPTION
## Summary

- Add an explicit `"name": "documenteer"` to `package.json`.
- Without a declared name, npm derives the `package-lock.json` name from the checkout directory. In the stoker devcontainer that directory is `/workspace`, so npm rewrites the committed lock name from `documenteer` to `workspace` on every install, leaving the lock file dirty.
- Declaring the name pins it consistently across host and devcontainer checkouts; the committed `package-lock.json` already uses `documenteer`, so no lock change is needed.

## Validation steps

- Open the repo in the stoker devcontainer (checked out under `/workspace`), run `npm install`, and confirm `git status` reports `package-lock.json` as clean.

## References

- Jira: https://rubinobs.atlassian.net/browse/DM-55292