### PR TITLE
DM-55292: Swap the pre-commit runner for prek

### DIFF
--- a/.agents/skills/project-mechanics/SKILL.md
+++ b/.agents/skills/project-mechanics/SKILL.md
@@ -9,30 +9,48 @@ This file is the source of truth for how this repo runs tests, lint,
 and type-checking. Profile-shipped phase skills read it at the start
 of each phase and use the named commands verbatim.
 
+Tasks run through nox (via nox-uv). Invoke nox through uv so the runner
+group is provisioned automatically: `uv run --only-group=nox nox ...`.
+The `test` and `typing` sessions are parametrized over Sphinx versions,
+so their session names carry the parameter, e.g. `test(sphinx='8')`.
+
 ## Test commands
 
-- `focused_test`: `tox -e py-test-sphinx8 -- -k <test_name>` (posargs after `--` pass through to pytest, so you can also use `tox -e py-test-sphinx8 -- tests/foo_test.py::test_bar`)
-- `complete_test`: `tox -e py-test-sphinx7,py-test-sphinx8`
+- `focused_test`: `uv run --only-group=nox nox -s "test(sphinx='8')" -- -k <test_name>` (posargs after `--` pass through to pytest, so you can also use `uv run --only-group=nox nox -s "test(sphinx='8')" -- tests/foo_test.py::test_bar`)
+- `complete_test`: `uv run --only-group=nox nox -s "test(sphinx='7')" "test(sphinx='8')"`
+
+## Coverage
+
+Coverage is opt-in. The `test` session runs plain pytest by default, so no
+`.coverage*` files are written during normal validation. To collect coverage
+and print a combined report across the test sessions, set the
+`DOCUMENTEER_COVERAGE` environment variable, e.g.
+`DOCUMENTEER_COVERAGE=1 uv run --only-group=nox nox -s "test(sphinx='7')" "test(sphinx='8')"`.
+The `coverage-report` session (combine + report) is triggered automatically
+via `session.notify` when `DOCUMENTEER_COVERAGE` is set, and can also be run
+directly to re-display the last combined report.
 
 ## Lint
 
-- `lint_touched`: `pre-commit run --files {files}`
-- `lint_all`: `tox -e lint`
+- `lint_touched`: `uv run --only-group=lint prek run --files {files}`
+- `lint_all`: `uv run --only-group=nox nox -s lint`
 
 ## Typing
 
-- `typing`: `tox -e typing-sphinx8`
+- `typing`: `uv run --only-group=nox nox -s "typing(sphinx='8')"`
 
 ## Final validation
 
-End-of-task validation runs `tox -e py-test-sphinx7,py-test-sphinx8` +
-`tox -e lint` + `tox -e typing-sphinx8` in that order, in the
-foreground, plus `tox -e demo` (end-to-end rst/md/ipynb demo technote
-builds) and `tox -e docs` (Documenteer's own Sphinx docs build).
+End-of-task validation runs `uv run --only-group=nox nox -s
+"test(sphinx='7')" "test(sphinx='8')"` + `uv run --only-group=nox nox -s
+lint` + `uv run --only-group=nox nox -s "typing(sphinx='8')"` in that
+order, in the foreground, plus `uv run --only-group=nox nox -s demo`
+(end-to-end rst/md/ipynb demo technote builds) and `uv run
+--only-group=nox nox -s docs` (Documenteer's own Sphinx docs build).
 
-The full Python × Sphinx matrix (3.12/3.13 × Sphinx 7/8), `tox -e
-docs-lint` (linkcheck), and `tox -e packaging` (build + twine check)
-are CI's responsibility, not the in-iteration gate.
+The full Python × Sphinx matrix (3.12/3.13 × Sphinx 7/8), `nox -s
+docs-linkcheck` (linkcheck), and `nox -s packaging` (build + twine
+check) are CI's responsibility, not the in-iteration gate.
 
 <!-- stoker-onboarded-from: github.com/lsst-sqre/rubin-stoker//profile@main
      prompt-hash: 348ec538f8f7f6fa42da3569d855eab629174668ef28ea225f8b37511daac9d4

--- a/.claude/skills/project-mechanics/SKILL.md
+++ b/.claude/skills/project-mechanics/SKILL.md
@@ -32,7 +32,7 @@ directly to re-display the last combined report.
 
 ## Lint
 
-- `lint_touched`: `uv run --only-group=lint pre-commit run --files {files}`
+- `lint_touched`: `uv run --only-group=lint prek run --files {files}`
 - `lint_all`: `uv run --only-group=nox nox -s lint`
 
 ## Typing

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,3 +23,9 @@ repos:
       - id: blacken-docs
         additional_dependencies: [black==25.1.0]
         args: [-l, '79', -t, py312]
+
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: v3.5.1
+    hooks:
+      - id: prettier
+        types_or: [css, scss, javascript]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ Tasks are run with [nox](https://nox.thea.codes/) (via [nox-uv](https://github.c
 nox -s "test(sphinx='8')"   # Run tests with Sphinx 8.x (also '7' or 'dev')
 nox -s coverage-report      # Generate coverage report
 nox -s "typing(sphinx='8')" # Run mypy type checking
-nox -s lint                 # Run linting (pre-commit hooks + prettier)
+nox -s lint                 # Run linting (prek hooks, incl. prettier)
 nox -s demo                 # Build demo technote projects (end-to-end test)
 nox -s packaging            # Check PyPI packaging
 ```

--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,12 @@ help:
 	@echo "Make command reference"
 	@echo "  make init ........ (initialize for development)"
 	@echo "  make clean ....... (clean up build artifacts)"
-	@echo "  make update-deps . (update dependencies and pre-commit hooks)"
+	@echo "  make update-deps . (update dependencies and prek hooks)"
 
 .PHONY: init
 init:
 	uv sync --extra technote --extra guide --group dev --group nox --group lint
-	uv run pre-commit install
+	uv run prek install
 
 .PHONY: clean
 clean:
@@ -20,4 +20,4 @@ clean:
 .PHONY: update-deps
 update-deps:
 	uv lock --upgrade
-	uv run --only-group=lint pre-commit autoupdate
+	uv run --only-group=lint prek autoupdate

--- a/docs/_rst_epilog.rst
+++ b/docs/_rst_epilog.rst
@@ -44,6 +44,7 @@
 .. _isort: https://pycqa.github.io/isort/
 .. _numpydoc: https://numpydoc.readthedocs.io/en/latest/index.html
 .. _pre-commit: https://pre-commit.com
+.. _prek: https://prek.j178.dev
 .. _pytest: https://pytest.org
 .. _toctree: http://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-toctree
 .. _linkcheck: https://www.sphinx-doc.org/en/master/usage/configuration.html?#options-for-the-linkcheck-builder

--- a/docs/dev/development.rst
+++ b/docs/dev/development.rst
@@ -34,17 +34,17 @@ To develop Documenteer, create a virtual environment with your method of choice 
 A complete environment also needs the compiled web assets (see :doc:`theme-assets`).
 Because the asset build pulls the private ``@lsst-sqre/rubin-style-dictionary`` package from GitHub Packages, you must first :ref:`authenticate npm to GitHub Packages <theme-assets-github-packages>` with a classic ``read:packages`` personal access token.
 
-.. _dev-pre-commit:
+.. _dev-prek:
 
-Code formatting and linting with pre-commit
-===========================================
+Code formatting and linting with prek
+=====================================
 
-Documenteer uses `pre-commit`_ to automatically and consistently format and lint the codebase on each commit.
-By running ``make init``, pre-commit is already installed in your environment.
+Documenteer uses `prek`_ (a drop-in, config-compatible replacement for pre-commit) to automatically and consistently format and lint the codebase on each commit.
+By running ``make init``, prek is already installed in your environment.
 
-If pre-commit "fails" because the black_ or isort_ code formatters changed the source, simply ``git add`` the changes and try the commit again.
+If prek "fails" because the black_ or isort_ code formatters changed the source, simply ``git add`` the changes and try the commit again.
 
-To learn more about the pre-commit configuration, see the ``.pre-commit-config.yaml`` file in the repository.
+To learn more about the hook configuration, see the ``.pre-commit-config.yaml`` file in the repository (prek reads the same configuration format as pre-commit).
 
 .. _dev-nox:
 
@@ -72,7 +72,7 @@ The available sessions are:
    * - ``typing``
      - Run mypy (type annotations checker). Parametrized over Sphinx versions (``7``, ``8``, ``dev``).
    * - ``lint``
-     - Run the pre-commit hooks and format the web assets with prettier.
+     - Run the prek hooks (including the prettier web-asset hook).
    * - ``coverage-report``
      - Aggregate unit test coverage reports from the ``test`` sessions and display a report. Runs automatically after the ``test`` sessions when ``DOCUMENTEER_COVERAGE`` is set.
    * - ``docs`` / ``docs-linkcheck``

--- a/noxfile.py
+++ b/noxfile.py
@@ -50,11 +50,8 @@ def _override_sphinx(session: nox.Session, sphinx: str) -> None:
 
 @session(uv_only_groups=["lint"], uv_no_install_project=True)
 def lint(session: nox.Session) -> None:
-    """Run pre-commit hooks and format web assets with prettier."""
-    session.run("pre-commit", "run", "--all-files", *session.posargs)
-    session.run(
-        "npx", "prettier", "**/*.{css,scss,js}", "--write", external=True
-    )
+    """Run the prek hooks (incl. the prettier web-asset hook)."""
+    session.run("prek", "run", "--all-files", *session.posargs)
 
 
 @session(uv_groups=["test"], uv_extras=_EXTRAS)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,9 +83,9 @@ nox = [
     "nox-uv>=0.6.1",
 ]
 lint = [
-    "pre-commit",
-    "pre-commit-uv",
+    "prek",
     "ruff",
+    "uv",
 ]
 test = [
     "coverage[toml]",

--- a/uv.lock
+++ b/uv.lock
@@ -598,9 +598,9 @@ docs = [
     { name = "sphinxcontrib-autoprogram" },
 ]
 lint = [
-    { name = "pre-commit" },
-    { name = "pre-commit-uv" },
+    { name = "prek" },
     { name = "ruff" },
+    { name = "uv" },
 ]
 nox = [
     { name = "nox" },
@@ -697,9 +697,9 @@ docs = [
     { name = "sphinxcontrib-autoprogram" },
 ]
 lint = [
-    { name = "pre-commit" },
-    { name = "pre-commit-uv" },
+    { name = "prek" },
     { name = "ruff" },
+    { name = "uv" },
 ]
 nox = [
     { name = "nox" },
@@ -1599,16 +1599,27 @@ wheels = [
 ]
 
 [[package]]
-name = "pre-commit-uv"
-version = "4.2.2"
+name = "prek"
+version = "0.4.5"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pre-commit" },
-    { name = "uv" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c7/94/3770b38b1643c3fc892ea7899f3671eb0f4d4fcbd33c1abe15641dfb1354/pre_commit_uv-4.2.2.tar.gz", hash = "sha256:8c94e1fb660ab3071fd32afb3bb4b43e1930612a8fec7cf03e9cfb7bffd5c5dc", size = 7447, upload-time = "2026-06-19T17:52:47.285Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2f/65/23866f43521d31173879aa74bb3a2df50ab7f3f74cdb4eaa31b8f446c7ca/prek-0.4.5.tar.gz", hash = "sha256:2be7bcf839de19a0144ed5a5aadf73bc5899cf6823bb1c58cf1d45ae389c201a", size = 482566, upload-time = "2026-06-15T11:36:48.299Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/90/bccb5c4b82cebd20b0b1464f6f03c07388327ddf143cf47deea72153f918/pre_commit_uv-4.2.2-py3-none-any.whl", hash = "sha256:5f86c77d8b1631a09a6b7c261247b235d46f0d757429c5aff3b52a63bc20dc62", size = 6184, upload-time = "2026-06-19T17:52:46.199Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/cb/a9eedf9a35ca6ec72f12af2b4392d7f757bb24863b7b7af4523f939cf3fa/prek-0.4.5-py3-none-linux_armv6l.whl", hash = "sha256:f7517774c72b001573520dc7111156779fd3e5b4452c11f09ff53c71a067e835", size = 5618105, upload-time = "2026-06-15T11:36:21.998Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a7/c96c06f17db7da0a57be2be4c229aa00b525bca8001c9c765663b339cbb7/prek-0.4.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:aca9fa995536036a0171bcf7a4db96dc0a14f480054eda1d7d1c2e7739650993", size = 5972998, upload-time = "2026-06-15T11:36:41.12Z" },
+    { url = "https://files.pythonhosted.org/packages/28/f1/721695355cdaa44be6f091e3a77fb9c72ed60289520f78b2f8c9a7197bdd/prek-0.4.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:66877ff21ae9d548f0f7e56fab8e65f1500a74a810e7749188c3f35a4a1b911b", size = 5525098, upload-time = "2026-06-15T11:36:30.127Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/1b/a334e1bb5361b49adf52b5ac7b6532018940f9f0f253437e8f43c3c1f7f3/prek-0.4.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:50697089a86a78d16f087c1912a2f3bc2bea82319a220fac52cc8e3ec9fc0426", size = 5793732, upload-time = "2026-06-15T11:36:35.745Z" },
+    { url = "https://files.pythonhosted.org/packages/28/8c/aff94d276e91207a87cedff7cfefdd4aca20444137cca77bf53fffebe77a/prek-0.4.5-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:590427a42a3c1e5064487a0dc91167ae0c8a52168e77f574758ef9b138fcfd61", size = 5521719, upload-time = "2026-06-15T11:36:39.383Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/73/cfb0c5c909442050a8357e26233f7e511ba8e0d2f4b0bdc460065d62beb6/prek-0.4.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1fd98b986767dafdb6b4305b563ee5a3a8f13bd3c78b98d708626815ea9f147f", size = 5922623, upload-time = "2026-06-15T11:36:18.063Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/ad/ff9d26551ba80d190bd08c6341176a5d56d4e6de9c2ebf077793d4adbb78/prek-0.4.5-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fccd11613ae92619d1ecda0ab3359ceebeb38898909ec84a8d383733d12158cc", size = 6722071, upload-time = "2026-06-15T11:36:43.086Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/43/11d1dfd66c919953fe89ae2fdedd4f413ee923883043816d35982177bb75/prek-0.4.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:14109d37b33e5529db41a3539d4f8f72d295f6eeddede3964994d898b8cec05c", size = 6176454, upload-time = "2026-06-15T11:36:33.803Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/d4/9749f25c2e0ee5225f812457b888acef301e0ccce64bebcda2ac1d04abee/prek-0.4.5-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:40d262418105b2ede9836593a1927fc927cc8093c432e998640964102196996e", size = 5791133, upload-time = "2026-06-15T11:36:23.891Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/72/5e0344bab1eacf813a5b1b082cb4c6253930096166dad51c1cccee0a4f83/prek-0.4.5-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a586d14c3b852fdee1c3dcd0b9cb0915db9f9d054334b854fd9470bf68edf129", size = 5658098, upload-time = "2026-06-15T11:36:44.862Z" },
+    { url = "https://files.pythonhosted.org/packages/be/a5/1f406e0362dd0f18ba09a562d50d7c04a70ac05d350b1ab6fba36ca3e9f0/prek-0.4.5-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:a8ed0d28f3e7790e4402a9324c386509066df6e67cc587f7406f9a245b97b7e8", size = 5498634, upload-time = "2026-06-15T11:36:31.828Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/df/b0cbf0fa527330188390b7b6c8d279cd5e509923262d0a6c5cc44bbdf103/prek-0.4.5-py3-none-musllinux_1_1_i686.whl", hash = "sha256:86f76bd3d2ecf6fd9034d75c62ff4c786eb11d0dd0a1f79bbb4343b023e12769", size = 5784840, upload-time = "2026-06-15T11:36:37.481Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/d7/977ee3c622c906677dd94187a00392ce2dd76035486b3a3b1b5a5267dd34/prek-0.4.5-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:e491a1a4641d91d8b03dcce5588397e76d2a5b432c9b0a6c70475972b4512ab4", size = 6300384, upload-time = "2026-06-15T11:36:27.602Z" },
+    { url = "https://files.pythonhosted.org/packages/79/fa/43b1d761381dc1c7eeb8f2235c66e902970d4b2bff2dec0f02836c085769/prek-0.4.5-py3-none-win32.whl", hash = "sha256:7546989b2403c96137bd79d19ebfe21facb87266cefe819db2458c3b9b23f350", size = 5287935, upload-time = "2026-06-15T11:36:20.293Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/fe/59b5eb3124f5a4cc255a93857b9ab42402635b273f157e91de23bfa40e8f/prek-0.4.5-py3-none-win_amd64.whl", hash = "sha256:8b2ac9227504371d97338215b344184cb0b31ca94113515a3a90c509c6c5a707", size = 5682560, upload-time = "2026-06-15T11:36:25.865Z" },
+    { url = "https://files.pythonhosted.org/packages/97/0e/589ff0eab9034909b1ec8654ee03483797305fb743b3554ce6140d82da9d/prek-0.4.5-py3-none-win_arm64.whl", hash = "sha256:646a86a1a082dbd99fed96314b1064f5644bb34c1f4037a63547a18e2160fb86", size = 5509019, upload-time = "2026-06-15T11:36:46.595Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Replace pre-commit with [prek](https://prek.j178.dev) (a faster, config-compatible runner) across the `lint` dependency group (`pre-commit`/`pre-commit-uv` → `prek`, `ruff`, `uv`), the nox `lint` session (now `prek run --all-files`), and the `Makefile` (`uv run prek install`; autoupdate via `prek`).
- Add a prettier mirror hook to `.pre-commit-config.yaml` (pinned to `v3.5.1`, scoped to CSS/SCSS/JS) and drop the standalone `npx prettier ... --write` step, so `prek run` is the single lint entrypoint covering web assets.
- Update `CLAUDE.md` and the `docs/dev/` lint references from pre-commit to prek (keeping the technote-author docs' pre-commit references intact, since those describe pre-commit for technote repos).

## Validation steps

- In a fresh checkout, run `make init` and confirm it installs the prek git hook (`uv run prek install` writes `.git/hooks/pre-commit`).
- Introduce a deliberately mis-formatted CSS/SCSS/JS edit and run a `git commit`; confirm the prettier hook (via prek) reformats it and the commit must be re-staged.

## References

- Closes #295
- PRD: #293
- Jira: https://rubinobs.atlassian.net/browse/DM-55292