### PR TITLE
DM-55600: Cache intersphinx inventories with an on-disk TTL and ETags

### DIFF
--- a/changelog.d/20260723_000000_jonathan_DM_55600_intersphinx_cache_ttl.md
+++ b/changelog.d/20260723_000000_jonathan_DM_55600_intersphinx_cache_ttl.md
@@ -1,0 +1,3 @@
+### New features
+
+- Prefetched intersphinx inventories are now cached on disk with a short time-to-live (the new `disk_cache_ttl` setting under `[sphinx.intersphinx_cache]`, default 600 seconds; `0` disables it), so rapid successive local rebuilds reuse the cached `objects.inv` without contacting Ook at all. Once the TTL expires, Documenteer revalidates conditionally: it sends the stored ETag as an `If-None-Match` header, and a `304 Not Modified` reuses the on-disk copy with no inventory body transferred (a `200 OK` replaces it). Technotes can override the TTL through `documenteer_intersphinx_cache_disk_cache_ttl` in `conf.py`.

--- a/docs/guides/toml-reference.rst
+++ b/docs/guides/toml-reference.rst
@@ -508,6 +508,9 @@ When the service fails for an individual inventory (an unauthorized or rejected 
 The fallback is logged at ``INFO`` rather than as a warning on purpose: Rubin documentation builds run with warnings-as-errors (``-W``), so reporting graceful service degradation as a warning would fail the build.
 An Ook outage can never make a build worse than a build without the service.
 
+To avoid re-downloading inventories on every build, Documenteer caches each prefetched :file:`objects.inv` on disk and only revalidates it with Ook after a short time-to-live (see :ref:`disk_cache_ttl <guide-sphinx-intersphinx-cache-disk-cache-ttl>` below).
+While a cached inventory is younger than the TTL, it is reused without contacting Ook at all; once the TTL has expired, Documenteer revalidates conditionally with an ``If-None-Match`` request, and a ``304 Not Modified`` reuses the on-disk copy with no inventory body transferred.
+
 .. note::
 
    **Technotes** also prefetch intersphinx inventories from the service, but technotes don't read :file:`documenteer.toml`, so the settings below don't apply to them; the defaults are used.
@@ -543,6 +546,29 @@ service_url
 
 Base URL of the Ook API that hosts the intersphinx inventory cache service.
 Default is ``https://roundtable.lsst.cloud/ook``.
+
+.. _guide-sphinx-intersphinx-cache-disk-cache-ttl:
+
+disk_cache_ttl
+--------------
+
+|optional|
+
+How long, in seconds, a prefetched inventory on disk is reused before Documenteer revalidates it with the Ook_ service.
+Default is ``600`` (10 minutes).
+
+While a cached :file:`objects.inv` is younger than the TTL, Documenteer reuses it as-is and makes no request to Ook, so rapid successive local rebuilds skip the round-trip entirely.
+Once the TTL has expired, Documenteer revalidates the inventory conditionally: it sends the ETag it stored alongside the cached file as an ``If-None-Match`` header, and if Ook answers ``304 Not Modified`` the on-disk copy is reused with no inventory body transferred and its TTL window restarts.
+A ``200 OK`` response replaces the cached inventory.
+
+Set ``disk_cache_ttl`` to ``0`` to disable this fast path so every build revalidates with Ook:
+
+.. code-block:: toml
+
+   [sphinx.intersphinx_cache]
+   disk_cache_ttl = 0
+
+The TTL governs only the client-to-Ook hop; whether Ook's own cached copy is current relative to the origin site remains Ook's concern.
 
 [sphinx.linkcheck]
 ==================

--- a/src/documenteer/conf/_toml.py
+++ b/src/documenteer/conf/_toml.py
@@ -201,6 +201,17 @@ class IntersphinxCacheModel(BaseModel):
         ),
     )
 
+    disk_cache_ttl: int = Field(
+        600,
+        description=(
+            "Seconds an on-disk cached inventory stays fresh before the "
+            "client revalidates it with Ook. Within this window, successive "
+            "builds reuse the local file without contacting Ook at all. "
+            "Set to 0 to disable the fast path so every build revalidates "
+            "with Ook."
+        ),
+    )
+
 
 class LinkCheckModel(BaseModel):
     """Model for linkcheck builder configurations in documenteer.toml."""
@@ -559,6 +570,13 @@ class DocumenteerConfig:
         service (without a trailing slash).
         """
         return str(self._intersphinx_cache.service_url).rstrip("/")
+
+    @property
+    def intersphinx_cache_disk_cache_ttl(self) -> int:
+        """Seconds an on-disk cached inventory stays fresh before the client
+        revalidates it with Ook (0 disables the fast path).
+        """
+        return self._intersphinx_cache.disk_cache_ttl
 
     def append_linkcheck_ignore(self, link_patterns: list[str]) -> None:
         """Append URL patterns for sphinx.linkcheck.ignore to existing

--- a/src/documenteer/conf/_toml.py
+++ b/src/documenteer/conf/_toml.py
@@ -203,6 +203,7 @@ class IntersphinxCacheModel(BaseModel):
 
     disk_cache_ttl: int = Field(
         600,
+        ge=0,
         description=(
             "Seconds an on-disk cached inventory stays fresh before the "
             "client revalidates it with Ook. Within this window, successive "

--- a/src/documenteer/conf/guide.py
+++ b/src/documenteer/conf/guide.py
@@ -75,6 +75,7 @@ __all__ = [
     "intersphinx_cache_limit",
     "documenteer_intersphinx_cache_use_service",
     "documenteer_intersphinx_cache_service_url",
+    "documenteer_intersphinx_cache_disk_cache_ttl",
     # LINKCHECK
     "linkcheck_retries",
     "linkcheck_ignore",
@@ -266,6 +267,9 @@ intersphinx_cache_limit = 5  # days
 # documenteer.ext.intersphinxcache
 documenteer_intersphinx_cache_use_service = _conf.intersphinx_cache_use_service
 documenteer_intersphinx_cache_service_url = _conf.intersphinx_cache_service_url
+documenteer_intersphinx_cache_disk_cache_ttl = (
+    _conf.intersphinx_cache_disk_cache_ttl
+)
 
 
 # ============================================================================

--- a/src/documenteer/ext/intersphinxcache.py
+++ b/src/documenteer/ext/intersphinxcache.py
@@ -244,9 +244,15 @@ def _revalidate_inventory(
             return None
         # Refresh the file's mtime to restart the TTL window (best-effort; a
         # failed refresh only means the next build revalidates sooner) and
-        # map to the local file.
+        # map to the local file. Reported at info level so build logs show
+        # that Ook was consulted and the on-disk copy is current.
         with contextlib.suppress(OSError):
             os.utime(inv_path, None)
+        logger.info(
+            "The intersphinx inventory for %r is unchanged on Ook "
+            "(HTTP 304 Not Modified); reusing the on-disk copy.",
+            name,
+        )
         return str(inv_path)
 
     content = result.content
@@ -273,6 +279,14 @@ def _revalidate_inventory(
     # ETag, or clear any stale sidecar when the server sent none (older-server
     # graceful degradation).
     _store_etag(etag_path, result.etag)
+    # Reported at info level so build logs show that the inventory came from
+    # the Ook cache (the local-path rewrite is otherwise only visible via
+    # intersphinx's own "loading intersphinx inventory from ..." lines).
+    logger.info(
+        "Downloaded the intersphinx inventory for %r from Ook (%d bytes).",
+        name,
+        len(content),
+    )
     return str(inv_path)
 
 
@@ -322,7 +336,13 @@ def _prefetch_inventories(app: Sphinx, config: Config) -> None:
             # to the local path exactly as it would be after a fresh prefetch.
             # The TTL governs only this client-to-Ook hop; whether Ook's own
             # cached copy is stale relative to the origin remains Ook's
-            # concern.
+            # concern. Reported at info level so build logs distinguish a
+            # cache hit from the extension not running at all.
+            logger.info(
+                "Reusing the on-disk intersphinx inventory for %r "
+                "(younger than disk_cache_ttl).",
+                name,
+            )
             mapping[name] = (target_uri, str(inv_path))
             continue
 

--- a/src/documenteer/ext/intersphinxcache.py
+++ b/src/documenteer/ext/intersphinxcache.py
@@ -92,17 +92,21 @@ _UNSAFE_FILENAME_CHARS = re.compile(r"[^A-Za-z0-9._-]")
 """Characters not allowed in a generated inventory filename stem."""
 
 
-def _inventory_filename(name: str) -> str:
-    """Return a filesystem-safe ``.inv`` filename for a mapping key.
+def _inventory_filename(name: str, origin_url: str) -> str:
+    """Return a filesystem-safe ``.inv`` filename for a mapping entry.
 
     The mapping key comes from an author-controlled ``intersphinx_mapping``
     and may contain path separators or other characters that are unsafe in a
     filename. The key is sanitized for readability and suffixed with a short
-    hash of the original key so distinct keys that sanitize to the same stem
-    do not collide.
+    hash of the original key *and* the resolved origin inventory URL. Hashing
+    the origin URL as well means that changing an entry's target URI or
+    inventory URL (while keeping the same key) yields a different filename, so
+    the new URL misses the cache and is fetched immediately rather than being
+    served the previously cached inventory for up to one TTL window. Including
+    the key keeps distinct keys that sanitize to the same stem from colliding.
     """
     safe = _UNSAFE_FILENAME_CHARS.sub("_", name)
-    digest = hashlib.sha256(name.encode("utf-8")).hexdigest()[:8]
+    digest = hashlib.sha256(f"{name}\n{origin_url}".encode()).hexdigest()[:8]
     return f"{safe}-{digest}{os.extsep}inv"
 
 
@@ -220,9 +224,27 @@ def _revalidate_inventory(
 
     if result.not_modified:
         # 304 Not Modified: the on-disk bytes are current and no body was
-        # transferred. Refresh the file's mtime to restart the TTL window
-        # (best-effort; a failed refresh only means the next build
-        # revalidates sooner) and map to the local file.
+        # transferred. This is only meaningful when we actually sent an
+        # If-None-Match (request_etag is not None) and the cached file is
+        # still present. A misbehaving server that answers 304 to an
+        # unconditional request would otherwise map the entry to a
+        # possibly-nonexistent local file, which intersphinx would then warn
+        # about as unreadable — under -W the one case that could make the
+        # build worse than not using the service at all. Treat that as a
+        # fallback: leave the entry untouched so stock intersphinx fetches
+        # the origin directly.
+        if request_etag is None or not inv_path.is_file():
+            logger.info(
+                "Ook returned 304 Not Modified for %r without a usable "
+                "cached inventory (no ETag was sent or the cache file is "
+                "missing); falling back to a direct fetch of %s.",
+                name,
+                origin_url,
+            )
+            return None
+        # Refresh the file's mtime to restart the TTL window (best-effort; a
+        # failed refresh only means the next build revalidates sooner) and
+        # map to the local file.
         with contextlib.suppress(OSError):
             os.utime(inv_path, None)
         return str(inv_path)
@@ -292,7 +314,7 @@ def _prefetch_inventories(app: Sphinx, config: Config) -> None:
         if origin_url is None:
             continue
 
-        inv_path = cache_dir / _inventory_filename(name)
+        inv_path = cache_dir / _inventory_filename(name, origin_url)
         etag_path = _etag_sidecar_path(inv_path)
         if ttl > 0 and _is_cache_fresh(inv_path, ttl):
             # TTL fast path: the on-disk inventory is younger than the TTL, so

--- a/src/documenteer/ext/intersphinxcache.py
+++ b/src/documenteer/ext/intersphinxcache.py
@@ -15,6 +15,14 @@ real upstream site and stock intersphinx runs unmodified. (Rationale:
 intersphinx cannot send an ``Authorization`` header to inventory URLs, but it
 accepts local file paths as inventory locations.)
 
+A client-side on-disk TTL avoids the Ook round-trip on rapid successive
+builds: when the cached ``.inv`` file for a mapping entry already exists with
+an mtime younger than ``documenteer_intersphinx_cache_disk_cache_ttl`` seconds
+(default 600), it is reused as-is without contacting Ook. Setting the TTL to
+``0`` disables this fast path so every build revalidates with Ook. The TTL
+governs only the client-to-Ook hop; whether Ook's own cached copy is stale
+relative to the origin remains Ook's concern.
+
 The extension is a complete no-op when ``OOK_TOKEN`` is unset (forks, local
 builds) or when disabled via ``documenteer_intersphinx_cache_use_service``.
 Any per-inventory client error (unauthorized, unreachable, 5xx, 404,
@@ -33,6 +41,7 @@ import hashlib
 import os
 import posixpath
 import re
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -106,6 +115,20 @@ def _resolve_origin_inventory_url(
     return None
 
 
+def _is_cache_fresh(path: Path, ttl: int) -> bool:
+    """Return whether a cached inventory file exists and its mtime is younger
+    than ``ttl`` seconds.
+
+    A missing file (or any stat error) is treated as not fresh so the caller
+    revalidates with Ook.
+    """
+    try:
+        mtime = path.stat().st_mtime
+    except OSError:
+        return False
+    return (time.time() - mtime) < ttl
+
+
 def _prefetch_inventories(app: Sphinx, config: Config) -> None:
     """Prefetch intersphinx inventories from Ook and rewrite the mapping.
 
@@ -133,6 +156,8 @@ def _prefetch_inventories(app: Sphinx, config: Config) -> None:
     # from the published HTML site, mirroring how .doctrees is excluded.
     cache_dir = Path(app.doctreedir).parent / CACHE_DIRNAME
 
+    ttl = config.documenteer_intersphinx_cache_disk_cache_ttl
+
     for name, value in list(mapping.items()):
         if not isinstance(value, (tuple, list)) or len(value) != 2:
             # An unexpected entry shape is left for intersphinx to validate.
@@ -140,6 +165,17 @@ def _prefetch_inventories(app: Sphinx, config: Config) -> None:
         target_uri, inv_location = value
         origin_url = _resolve_origin_inventory_url(target_uri, inv_location)
         if origin_url is None:
+            continue
+
+        inv_path = cache_dir / _inventory_filename(name)
+        if ttl > 0 and _is_cache_fresh(inv_path, ttl):
+            # TTL fast path: the on-disk inventory is younger than the TTL, so
+            # reuse it without contacting Ook at all. The mapping is rewritten
+            # to the local path exactly as it would be after a fresh prefetch.
+            # The TTL governs only this client-to-Ook hop; whether Ook's own
+            # cached copy is stale relative to the origin remains Ook's
+            # concern.
+            mapping[name] = (target_uri, str(inv_path))
             continue
 
         try:
@@ -161,7 +197,6 @@ def _prefetch_inventories(app: Sphinx, config: Config) -> None:
             )
             continue
 
-        inv_path = cache_dir / _inventory_filename(name)
         try:
             cache_dir.mkdir(parents=True, exist_ok=True)
             inv_path.write_bytes(data)
@@ -207,6 +242,9 @@ def setup(app: Sphinx) -> ExtensionMetadata:
     app.add_config_value("documenteer_intersphinx_cache_use_service", True, "")
     app.add_config_value(
         "documenteer_intersphinx_cache_service_url", DEFAULT_BASE_URL, ""
+    )
+    app.add_config_value(
+        "documenteer_intersphinx_cache_disk_cache_ttl", 600, ""
     )
 
     return {

--- a/src/documenteer/ext/intersphinxcache.py
+++ b/src/documenteer/ext/intersphinxcache.py
@@ -23,6 +23,17 @@ an mtime younger than ``documenteer_intersphinx_cache_disk_cache_ttl`` seconds
 governs only the client-to-Ook hop; whether Ook's own cached copy is stale
 relative to the origin remains Ook's concern.
 
+When the TTL has expired and a cached inventory plus its ETag sidecar exist,
+the revalidation is conditional: the ETag Ook returned is persisted next to
+the ``.inv`` file as ``<name>-<hash>.inv.etag`` and sent back as an
+``If-None-Match`` header. If Ook answers ``304 Not Modified`` the on-disk
+bytes are reused with no body transferred, the file's mtime is refreshed to
+restart the TTL window, and the mapping is rewritten to the local file. A
+``200 OK`` replaces both the ``.inv`` file and its sidecar. Against an older
+Ook that returns no ``ETag`` header the behavior is exactly the pre-ETag
+path — a full download with no sidecar — and a ``200`` without an ETag clears
+any stale sidecar.
+
 The extension is a complete no-op when ``OOK_TOKEN`` is unset (forks, local
 builds) or when disabled via ``documenteer_intersphinx_cache_use_service``.
 Any per-inventory client error (unauthorized, unreachable, 5xx, 404,
@@ -37,6 +48,7 @@ service, which likewise logs service-side conditions at INFO.)
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import os
 import posixpath
@@ -129,6 +141,119 @@ def _is_cache_fresh(path: Path, ttl: int) -> bool:
     return (time.time() - mtime) < ttl
 
 
+def _etag_sidecar_path(inv_path: Path) -> Path:
+    """Return the ETag sidecar path for a cached inventory file.
+
+    The sidecar sits next to the ``.inv`` file with an added ``.etag``
+    suffix (e.g. ``<name>-<hash>.inv.etag``) and holds the entity tag Ook
+    returned for the cached bytes, used for ``If-None-Match`` revalidation.
+    """
+    return inv_path.with_name(inv_path.name + os.extsep + "etag")
+
+
+def _read_etag(etag_path: Path) -> str | None:
+    """Return the stored ETag for a cached inventory, or `None`.
+
+    A missing or unreadable sidecar (or an empty one) yields `None` so the
+    caller revalidates with a full request rather than a conditional one.
+    """
+    try:
+        return etag_path.read_text(encoding="utf-8").strip() or None
+    except OSError:
+        return None
+
+
+def _store_etag(etag_path: Path, etag: str | None) -> None:
+    """Persist (or clear) the ETag sidecar for a cached inventory.
+
+    Writing the sidecar is best-effort: when ``etag`` is `None` (the server
+    sent no ``ETag`` header) any stale sidecar is removed so a later build
+    does not revalidate against a tag the current bytes never had. A
+    filesystem error is swallowed because the inventory itself is already
+    written; the only consequence is that the next build falls back to a full
+    (unconditional) fetch, never a build failure.
+    """
+    try:
+        if etag is None:
+            etag_path.unlink(missing_ok=True)
+        else:
+            etag_path.write_text(etag, encoding="utf-8")
+    except OSError:
+        pass
+
+
+def _revalidate_inventory(
+    client: IntersphinxCacheClient,
+    name: str,
+    origin_url: str,
+    inv_path: Path,
+    etag_path: Path,
+) -> str | None:
+    """Fetch or revalidate one inventory and return the local path to map to.
+
+    Sends ``If-None-Match`` only when both a cached inventory and its ETag
+    sidecar exist, so a ``304`` can safely reuse the on-disk bytes. Returns
+    the local file path to rewrite the mapping entry to, or `None` to leave
+    the entry untouched (a client error or a cache write failure), so stock
+    intersphinx fetches the origin directly and the build is never worse than
+    without the service.
+    """
+    request_etag: str | None = None
+    if inv_path.is_file() and etag_path.is_file():
+        request_etag = _read_etag(etag_path)
+
+    try:
+        result = client.get_inventory(origin_url, etag=request_etag)
+    except IntersphinxCacheError as e:
+        # Reported at info (not warning) level so a warnings-as-errors
+        # (``-W``) build does not fail on graceful service degradation (e.g.
+        # Ook returning 404 for a not-yet-deployed endpoint), matching the
+        # linkcheck-service precedent in ``linkcheckservice.py``.
+        logger.info(
+            "Could not prefetch the intersphinx inventory for %r from "
+            "Ook (%s); falling back to a direct fetch of %s.",
+            name,
+            e,
+            origin_url,
+        )
+        return None
+
+    if result.not_modified:
+        # 304 Not Modified: the on-disk bytes are current and no body was
+        # transferred. Refresh the file's mtime to restart the TTL window
+        # (best-effort; a failed refresh only means the next build
+        # revalidates sooner) and map to the local file.
+        with contextlib.suppress(OSError):
+            os.utime(inv_path, None)
+        return str(inv_path)
+
+    content = result.content
+    if content is None:
+        # Defensive: a non-304 response always carries bytes. Treat an empty
+        # payload as a fallback rather than writing a truncated inventory.
+        return None
+    try:
+        inv_path.parent.mkdir(parents=True, exist_ok=True)
+        inv_path.write_bytes(content)
+    except OSError as e:
+        # A filesystem error writing the cache leaves this entry untouched;
+        # reported at info level for the same warnings-as-errors reason.
+        logger.info(
+            "Could not write the prefetched intersphinx inventory for "
+            "%r to %s (%s); falling back to a direct fetch of %s.",
+            name,
+            inv_path,
+            e,
+            origin_url,
+        )
+        return None
+    # Reconcile the ETag sidecar with the freshly written bytes: store the new
+    # ETag, or clear any stale sidecar when the server sent none (older-server
+    # graceful degradation).
+    _store_etag(etag_path, result.etag)
+    return str(inv_path)
+
+
 def _prefetch_inventories(app: Sphinx, config: Config) -> None:
     """Prefetch intersphinx inventories from Ook and rewrite the mapping.
 
@@ -168,6 +293,7 @@ def _prefetch_inventories(app: Sphinx, config: Config) -> None:
             continue
 
         inv_path = cache_dir / _inventory_filename(name)
+        etag_path = _etag_sidecar_path(inv_path)
         if ttl > 0 and _is_cache_fresh(inv_path, ttl):
             # TTL fast path: the on-disk inventory is younger than the TTL, so
             # reuse it without contacting Ook at all. The mapping is rewritten
@@ -178,47 +304,15 @@ def _prefetch_inventories(app: Sphinx, config: Config) -> None:
             mapping[name] = (target_uri, str(inv_path))
             continue
 
-        try:
-            data = client.get_inventory(origin_url)
-        except IntersphinxCacheError as e:
-            # Any client error leaves this entry untouched so stock
-            # intersphinx fetches the origin directly; the build is never
-            # worse than without the service. Reported at info (not warning)
-            # level so a warnings-as-errors (``-W``) build does not fail on
-            # graceful service degradation (e.g. Ook returning 404 for a
-            # not-yet-deployed endpoint), matching the linkcheck-service
-            # precedent in ``linkcheckservice.py``.
-            logger.info(
-                "Could not prefetch the intersphinx inventory for %r from "
-                "Ook (%s); falling back to a direct fetch of %s.",
-                name,
-                e,
-                origin_url,
-            )
-            continue
-
-        try:
-            cache_dir.mkdir(parents=True, exist_ok=True)
-            inv_path.write_bytes(data)
-        except OSError as e:
-            # A filesystem error writing the cache leaves this entry
-            # untouched so stock intersphinx fetches the origin directly;
-            # the build is never worse than without the service. Reported at
-            # info (not warning) level so a warnings-as-errors (``-W``) build
-            # does not fail on graceful degradation, matching the
-            # linkcheck-service precedent in ``linkcheckservice.py``.
-            logger.info(
-                "Could not write the prefetched intersphinx inventory for "
-                "%r to %s (%s); falling back to a direct fetch of %s.",
-                name,
-                inv_path,
-                e,
-                origin_url,
-            )
-            continue
-        # Rewrite only the inventory location; the target URI is left
-        # unchanged so resolved links still point at the upstream site.
-        mapping[name] = (target_uri, str(inv_path))
+        # The TTL has expired (or there is no cached copy). Revalidate with
+        # Ook; on success rewrite only the inventory location (the target URI
+        # is left unchanged so resolved links still point at the upstream
+        # site). A None result leaves the entry untouched as a fallback.
+        local_path = _revalidate_inventory(
+            client, name, origin_url, inv_path, etag_path
+        )
+        if local_path is not None:
+            mapping[name] = (target_uri, local_path)
 
 
 def setup(app: Sphinx) -> ExtensionMetadata:

--- a/src/documenteer/storage/intersphinxcacheclient.py
+++ b/src/documenteer/storage/intersphinxcacheclient.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from dataclasses import dataclass
 
 import requests
 
@@ -16,6 +17,7 @@ __all__ = [
     "IntersphinxCacheServerError",
     "IntersphinxCacheUnauthorizedError",
     "IntersphinxCacheUnreachableError",
+    "InventoryFetchResult",
 ]
 
 DEFAULT_BASE_URL = "https://roundtable.lsst.cloud/ook"
@@ -23,6 +25,28 @@ DEFAULT_BASE_URL = "https://roundtable.lsst.cloud/ook"
 
 TOKEN_ENV_VAR = "OOK_TOKEN"
 """Environment variable holding the bearer token for the Ook API."""
+
+
+@dataclass(frozen=True)
+class InventoryFetchResult:
+    """The outcome of a (possibly conditional) inventory fetch.
+
+    A ``304 Not Modified`` response is signaled by ``not_modified`` being
+    `True` with ``content`` `None`; a ``200 OK`` carries the fetched bytes in
+    ``content`` with ``not_modified`` `False`. ``etag`` is the entity tag the
+    caller should persist alongside the inventory: on a 200 it is the ETag
+    from the response (or `None` when the server sent no ``ETag`` header), and
+    on a 304 it is the ETag that was revalidated.
+    """
+
+    not_modified: bool
+    """Whether the server reported the inventory unchanged (HTTP 304)."""
+
+    content: bytes | None
+    """The raw inventory bytes on a 200, or `None` on a 304."""
+
+    etag: str | None
+    """The entity tag to persist, or `None` when the server sent none."""
 
 
 class IntersphinxCacheError(ValueError):
@@ -88,7 +112,9 @@ class IntersphinxCacheClient:
             session if session is not None else requests_retry_session()
         )
 
-    def get_inventory(self, url: str) -> bytes:
+    def get_inventory(
+        self, url: str, *, etag: str | None = None
+    ) -> InventoryFetchResult:
         """Fetch the cached intersphinx inventory for an origin URL.
 
         Parameters
@@ -96,12 +122,17 @@ class IntersphinxCacheClient:
         url
             The origin ``objects.inv`` URL to fetch from the cache, passed
             to the service as the ``url`` query parameter.
+        etag
+            An entity tag from a previously cached copy. When provided, the
+            request carries an ``If-None-Match`` header so an unchanged
+            inventory can be answered with ``304 Not Modified`` and no body.
 
         Returns
         -------
-        bytes
-            The raw inventory bytes, returned unparsed for the caller to
-            write to a local file.
+        InventoryFetchResult
+            The fetch outcome: either new bytes plus the response ETag
+            (``not_modified=False``), or a not-modified signal that echoes the
+            revalidated ``etag`` (``not_modified=True``, ``content=None``).
 
         Raises
         ------
@@ -124,6 +155,10 @@ class IntersphinxCacheClient:
             )
         api_url = f"{self._base_url}/intersphinx/inventory"
         headers = {"Authorization": f"Bearer {self._token}"}
+        if etag is not None:
+            # Conditional revalidation: an unchanged inventory is answered
+            # with 304 and transfers no body.
+            headers["If-None-Match"] = etag
         try:
             r = self._session.get(
                 api_url,
@@ -151,6 +186,13 @@ class IntersphinxCacheClient:
                 f"cache at {api_url} (HTTP {r.status_code}). Check the "
                 f"{TOKEN_ENV_VAR} environment variable."
             )
+        if r.status_code == 304:
+            # The conditional request matched: the inventory is unchanged, so
+            # the caller keeps its on-disk copy. Echo back the ETag it
+            # revalidated with.
+            return InventoryFetchResult(
+                not_modified=True, content=None, etag=etag
+            )
         if r.status_code >= 500:
             raise IntersphinxCacheServerError(
                 f"Server error from the Ook intersphinx inventory cache at "
@@ -168,4 +210,8 @@ class IntersphinxCacheClient:
                 f"Error from the Ook intersphinx inventory cache at "
                 f"{api_url} for {url}: {e}"
             ) from e
-        return r.content
+        return InventoryFetchResult(
+            not_modified=False,
+            content=r.content,
+            etag=r.headers.get("ETag"),
+        )

--- a/tests/ext/intersphinxcache_test.py
+++ b/tests/ext/intersphinxcache_test.py
@@ -133,6 +133,84 @@ def test_prefetch_rewrites_mapping_and_resolves(
 
 @pytest.mark.sphinx(
     "html",
+    testroot="intersphinx-cache",
+    srcdir="intersphinx-cache-ttl-fastpath",
+)
+def test_ttl_fast_path_skips_ook_on_second_build(
+    make_app: Any,
+    app_params: Any,
+    responses: RequestsMock,
+    monkeypatch: Any,
+) -> None:
+    """A second build within disk_cache_ttl reuses the on-disk inventory
+    without contacting Ook, and the mapping is still rewritten to the local
+    cache file.
+    """
+    monkeypatch.setenv("OOK_TOKEN", "test-token")
+    origin_inv_url = "https://example.com/project/objects.inv"
+    responses.get(
+        INVENTORY_ENDPOINT,
+        body=_make_inventory(),
+        status=200,
+        content_type="application/octet-stream",
+        match=[matchers.query_param_matcher({"url": origin_inv_url})],
+    )
+
+    # The first build fetches from Ook and writes the on-disk cache.
+    app1 = _make_app(make_app, app_params)
+    app1.build()
+    assert len(responses.calls) == 1
+
+    # A second build within the TTL (the default 600s) reuses the on-disk
+    # inventory without contacting Ook at all.
+    app2 = _make_app(make_app, app_params)
+    app2.build()
+    assert len(responses.calls) == 1
+
+    # The mapping is still rewritten to the local cache file.
+    locations = _inventory_locations(app2, "testproj")
+    assert len(locations) == 1
+    assert "://" not in locations[0]
+    assert Path(locations[0]).is_file()
+
+
+@pytest.mark.sphinx(
+    "html",
+    testroot="intersphinx-cache",
+    srcdir="intersphinx-cache-ttl-disabled",
+    confoverrides={"documenteer_intersphinx_cache_disk_cache_ttl": 0},
+)
+def test_ttl_zero_revalidates_every_build(
+    make_app: Any,
+    app_params: Any,
+    responses: RequestsMock,
+    monkeypatch: Any,
+) -> None:
+    """With disk_cache_ttl = 0 the fast path is disabled, so every build
+    revalidates with Ook even when a fresh on-disk cache file exists.
+    """
+    monkeypatch.setenv("OOK_TOKEN", "test-token")
+    origin_inv_url = "https://example.com/project/objects.inv"
+    responses.get(
+        INVENTORY_ENDPOINT,
+        body=_make_inventory(),
+        status=200,
+        content_type="application/octet-stream",
+        match=[matchers.query_param_matcher({"url": origin_inv_url})],
+    )
+
+    app1 = _make_app(make_app, app_params)
+    app1.build()
+    assert len(responses.calls) == 1
+
+    # A second build contacts Ook again because the fast path is disabled.
+    app2 = _make_app(make_app, app_params)
+    app2.build()
+    assert len(responses.calls) == 2
+
+
+@pytest.mark.sphinx(
+    "html",
     testroot="intersphinx-cache-multi",
     srcdir="intersphinx-cache-fallback",
 )
@@ -399,6 +477,7 @@ def test_guide_preset_registers_extension(
     assert app.config.documenteer_intersphinx_cache_service_url == (
         OOK_BASE_URL
     )
+    assert app.config.documenteer_intersphinx_cache_disk_cache_ttl == 600
 
 
 @pytest.mark.skipif(
@@ -426,3 +505,4 @@ def test_technote_preset_registers_extension(
     assert app.config.documenteer_intersphinx_cache_service_url == (
         OOK_BASE_URL
     )
+    assert app.config.documenteer_intersphinx_cache_disk_cache_ttl == 600

--- a/tests/ext/intersphinxcache_test.py
+++ b/tests/ext/intersphinxcache_test.py
@@ -13,7 +13,7 @@ import pytest_responses  # noqa: F401
 from responses import RequestsMock, matchers
 from sphinx.testing.util import SphinxTestApp
 
-from documenteer.ext.intersphinxcache import CACHE_DIRNAME
+from documenteer.ext.intersphinxcache import CACHE_DIRNAME, _inventory_filename
 
 OOK_BASE_URL = "https://roundtable.lsst.cloud/ook"
 INVENTORY_ENDPOINT = f"{OOK_BASE_URL}/intersphinx/inventory"
@@ -274,6 +274,50 @@ def test_revalidation_304_reuses_disk_bytes(
     assert Path(locations[0]) == inv_path
     assert inv_path.read_bytes() == inventory
     assert sidecar.read_text() == etag
+
+
+@pytest.mark.sphinx(
+    "html",
+    testroot="intersphinx-cache",
+    srcdir="intersphinx-cache-unconditional-304",
+)
+def test_unconditional_304_falls_back(
+    make_app: Any,
+    app_params: Any,
+    responses: RequestsMock,
+    monkeypatch: Any,
+) -> None:
+    """A protocol-violating 304 answered to an unconditional request (no
+    cached inventory, so no If-None-Match was sent) is treated as a fallback:
+    the entry is left untouched with an info-level log rather than mapped to a
+    nonexistent local file.
+    """
+    monkeypatch.setenv("OOK_TOKEN", "test-token")
+    origin_inv_url = "https://example.com/project/objects.inv"
+    # The very first build has no cached .inv/sidecar, so it sends no
+    # If-None-Match; a misbehaving server answers 304 anyway.
+    responses.get(
+        INVENTORY_ENDPOINT,
+        status=304,
+        match=[matchers.query_param_matcher({"url": origin_inv_url})],
+    )
+
+    app = _make_app(make_app, app_params)
+    app.build()
+
+    # The fallback is reported at info level (not a warning, so a
+    # warnings-as-errors ``-W`` build does not fail on the misbehavior) and
+    # names the inventory, and the entry is left untouched (its inventory
+    # location is still None) so stock intersphinx fetches the origin directly.
+    status = app.status.getvalue()
+    assert "testproj" in status
+    assert "304 Not Modified" in status
+    assert "304 Not Modified" not in app.warning.getvalue()
+    assert _inventory_locations(app, "testproj") == (None,)
+    # No local cache file was mapped in, so nothing points at a possibly
+    # nonexistent path.
+    cache_dir = Path(app.doctreedir).parent / CACHE_DIRNAME
+    assert not any(cache_dir.glob("*.inv")) if cache_dir.exists() else True
 
 
 @pytest.mark.sphinx(
@@ -560,10 +604,33 @@ def test_per_inventory_fallback(
     )
 
 
+def test_inventory_filename_keys_on_name_and_origin_url() -> None:
+    """The cache filename hash includes the resolved origin URL, so changing
+    an entry's URL (while keeping the same key) yields a different filename —
+    the new URL misses the cache and is fetched immediately rather than served
+    a stale inventory for up to one TTL window.
+    """
+    name = "proj"
+    url_a = "https://a.example.com/objects.inv"
+    url_b = "https://b.example.com/objects.inv"
+
+    # Deterministic for identical inputs.
+    assert _inventory_filename(name, url_a) == _inventory_filename(name, url_a)
+    # A changed origin URL changes the filename.
+    assert _inventory_filename(name, url_a) != _inventory_filename(name, url_b)
+    # A changed key still changes the filename (distinct keys never collide).
+    assert _inventory_filename("other", url_a) != _inventory_filename(
+        name, url_a
+    )
+    # The stem is still the sanitized key and the suffix is still .inv.
+    assert _inventory_filename(name, url_a).startswith("proj-")
+    assert _inventory_filename(name, url_a).endswith(".inv")
+
+
 @pytest.mark.sphinx(
     "html",
     testroot="intersphinx-cache-oddkey",
-    srcdir="intersphinx-cache-oddkey",
+    srcdir="intersphinx-cache-oddkey-sanitize",
 )
 def test_mapping_key_with_path_separator_is_sanitized(
     make_app: Any,

--- a/tests/ext/intersphinxcache_test.py
+++ b/tests/ext/intersphinxcache_test.py
@@ -209,6 +209,283 @@ def test_ttl_zero_revalidates_every_build(
     assert len(responses.calls) == 2
 
 
+def _etag_sidecar(inv_path: Path) -> Path:
+    """Return the ETag sidecar path for a cached ``.inv`` file."""
+    return inv_path.with_name(inv_path.name + ".etag")
+
+
+@pytest.mark.sphinx(
+    "html",
+    testroot="intersphinx-cache",
+    srcdir="intersphinx-cache-etag-304",
+    confoverrides={"documenteer_intersphinx_cache_disk_cache_ttl": 0},
+)
+def test_revalidation_304_reuses_disk_bytes(
+    make_app: Any,
+    app_params: Any,
+    responses: RequestsMock,
+    monkeypatch: Any,
+) -> None:
+    """After the TTL expires, a revalidation that returns 304 reuses the
+    on-disk inventory (no body transferred) and rewrites the mapping to the
+    local file.
+    """
+    monkeypatch.setenv("OOK_TOKEN", "test-token")
+    origin_inv_url = "https://example.com/project/objects.inv"
+    etag = '"v1etag"'
+    inventory = _make_inventory()
+    # The 304 (registered first) is chosen only when If-None-Match is sent;
+    # the initial build has no such header and falls through to the 200.
+    responses.get(
+        INVENTORY_ENDPOINT,
+        status=304,
+        match=[
+            matchers.query_param_matcher({"url": origin_inv_url}),
+            matchers.header_matcher({"If-None-Match": etag}),
+        ],
+    )
+    responses.get(
+        INVENTORY_ENDPOINT,
+        body=inventory,
+        status=200,
+        content_type="application/octet-stream",
+        headers={"ETag": etag},
+        match=[matchers.query_param_matcher({"url": origin_inv_url})],
+    )
+
+    # First build fetches a 200 with an ETag and writes the .inv + sidecar.
+    app1 = _make_app(make_app, app_params)
+    app1.build()
+    assert len(responses.calls) == 1
+    inv_path = Path(_inventory_locations(app1, "testproj")[0])
+    sidecar = _etag_sidecar(inv_path)
+    assert sidecar.read_text() == etag
+
+    # Second build revalidates with If-None-Match and gets a 304.
+    app2 = _make_app(make_app, app_params)
+    app2.build()
+    assert len(responses.calls) == 2
+    assert responses.calls[1].request.headers["If-None-Match"] == etag
+
+    # The on-disk bytes are reused unchanged and the mapping still points at
+    # the local file; the sidecar is preserved.
+    locations = _inventory_locations(app2, "testproj")
+    assert "://" not in locations[0]
+    assert Path(locations[0]) == inv_path
+    assert inv_path.read_bytes() == inventory
+    assert sidecar.read_text() == etag
+
+
+@pytest.mark.sphinx(
+    "html",
+    testroot="intersphinx-cache",
+    srcdir="intersphinx-cache-etag-200",
+    confoverrides={"documenteer_intersphinx_cache_disk_cache_ttl": 0},
+)
+def test_revalidation_200_replaces_inv_and_sidecar(
+    make_app: Any,
+    app_params: Any,
+    responses: RequestsMock,
+    monkeypatch: Any,
+) -> None:
+    """A revalidation that returns 200 replaces both the .inv file and the
+    ETag sidecar.
+    """
+    monkeypatch.setenv("OOK_TOKEN", "test-token")
+    origin_inv_url = "https://example.com/project/objects.inv"
+    inv_v1 = _make_inventory(version="1.0")
+    inv_v2 = _make_inventory(version="2.0")
+    # When If-None-Match "v1" is sent, the server returns fresh bytes + v2.
+    responses.get(
+        INVENTORY_ENDPOINT,
+        body=inv_v2,
+        status=200,
+        content_type="application/octet-stream",
+        headers={"ETag": '"v2"'},
+        match=[
+            matchers.query_param_matcher({"url": origin_inv_url}),
+            matchers.header_matcher({"If-None-Match": '"v1"'}),
+        ],
+    )
+    responses.get(
+        INVENTORY_ENDPOINT,
+        body=inv_v1,
+        status=200,
+        content_type="application/octet-stream",
+        headers={"ETag": '"v1"'},
+        match=[matchers.query_param_matcher({"url": origin_inv_url})],
+    )
+
+    app1 = _make_app(make_app, app_params)
+    app1.build()
+    inv_path = Path(_inventory_locations(app1, "testproj")[0])
+    sidecar = _etag_sidecar(inv_path)
+    assert inv_path.read_bytes() == inv_v1
+    assert sidecar.read_text() == '"v1"'
+
+    app2 = _make_app(make_app, app_params)
+    app2.build()
+    assert len(responses.calls) == 2
+
+    # Both the inventory bytes and the sidecar are replaced with the new copy.
+    assert inv_path.read_bytes() == inv_v2
+    assert sidecar.read_text() == '"v2"'
+
+
+@pytest.mark.sphinx(
+    "html",
+    testroot="intersphinx-cache",
+    srcdir="intersphinx-cache-no-etag",
+    confoverrides={"documenteer_intersphinx_cache_disk_cache_ttl": 0},
+)
+def test_no_etag_server_full_fetch_no_sidecar(
+    make_app: Any,
+    app_params: Any,
+    responses: RequestsMock,
+    monkeypatch: Any,
+) -> None:
+    """Against a server that returns no ETag, behavior is today's: a full
+    fetch on every TTL miss, no sidecar written, and no warnings.
+    """
+    monkeypatch.setenv("OOK_TOKEN", "test-token")
+    origin_inv_url = "https://example.com/project/objects.inv"
+    responses.get(
+        INVENTORY_ENDPOINT,
+        body=_make_inventory(),
+        status=200,
+        content_type="application/octet-stream",
+        match=[matchers.query_param_matcher({"url": origin_inv_url})],
+    )
+
+    app1 = _make_app(make_app, app_params)
+    app1.build()
+    assert len(responses.calls) == 1
+    inv_path = Path(_inventory_locations(app1, "testproj")[0])
+    assert not _etag_sidecar(inv_path).exists()
+
+    # A second build (TTL disabled) fetches the full body again; still no
+    # sidecar and no warnings.
+    app2 = _make_app(make_app, app_params)
+    app2.build()
+    assert len(responses.calls) == 2
+    assert not _etag_sidecar(inv_path).exists()
+    # The extension itself emits no warning (the only lines in the warning
+    # stream are Sphinx's own multi-app node-registration noise from building
+    # two apps in one process, which does not occur in a real build).
+    warning = app2.warning.getvalue()
+    assert "Could not" not in warning
+    assert "intersphinx inventory" not in warning
+
+
+@pytest.mark.sphinx(
+    "html",
+    testroot="intersphinx-cache",
+    srcdir="intersphinx-cache-etag-cleared",
+    confoverrides={"documenteer_intersphinx_cache_disk_cache_ttl": 0},
+)
+def test_200_without_etag_clears_stale_sidecar(
+    make_app: Any,
+    app_params: Any,
+    responses: RequestsMock,
+    monkeypatch: Any,
+) -> None:
+    """A 200 response without an ETag clears any stale sidecar left by a
+    previous ETag-bearing response (e.g. after a server downgrade).
+    """
+    monkeypatch.setenv("OOK_TOKEN", "test-token")
+    origin_inv_url = "https://example.com/project/objects.inv"
+    # The revalidation (If-None-Match "v1") is answered by a downgraded server
+    # with a 200 that carries no ETag header.
+    responses.get(
+        INVENTORY_ENDPOINT,
+        body=_make_inventory(version="2.0"),
+        status=200,
+        content_type="application/octet-stream",
+        match=[
+            matchers.query_param_matcher({"url": origin_inv_url}),
+            matchers.header_matcher({"If-None-Match": '"v1"'}),
+        ],
+    )
+    responses.get(
+        INVENTORY_ENDPOINT,
+        body=_make_inventory(version="1.0"),
+        status=200,
+        content_type="application/octet-stream",
+        headers={"ETag": '"v1"'},
+        match=[matchers.query_param_matcher({"url": origin_inv_url})],
+    )
+
+    app1 = _make_app(make_app, app_params)
+    app1.build()
+    inv_path = Path(_inventory_locations(app1, "testproj")[0])
+    sidecar = _etag_sidecar(inv_path)
+    assert sidecar.read_text() == '"v1"'
+
+    app2 = _make_app(make_app, app_params)
+    app2.build()
+    assert len(responses.calls) == 2
+    # The stale sidecar is removed and the mapping still points at the file.
+    assert not sidecar.exists()
+    assert Path(_inventory_locations(app2, "testproj")[0]) == inv_path
+
+
+@pytest.mark.sphinx(
+    "html",
+    testroot="intersphinx-cache",
+    srcdir="intersphinx-cache-etag-error",
+    confoverrides={"documenteer_intersphinx_cache_disk_cache_ttl": 0},
+)
+def test_revalidation_error_leaves_mapping_untouched(
+    make_app: Any,
+    app_params: Any,
+    responses: RequestsMock,
+    monkeypatch: Any,
+) -> None:
+    """A client error during revalidation leaves the mapping entry untouched
+    with an info-level log, and the build still succeeds via a direct origin
+    fetch.
+    """
+    monkeypatch.setenv("OOK_TOKEN", "test-token")
+    origin_inv_url = "https://example.com/project/objects.inv"
+    # The revalidation fails with a client error. A 404 (not a force-listed
+    # 5xx) is answered on the first attempt without the retry session
+    # consuming the fallback 200, keeping the scenario deterministic.
+    responses.get(
+        INVENTORY_ENDPOINT,
+        json={"detail": "not found"},
+        status=404,
+        match=[
+            matchers.query_param_matcher({"url": origin_inv_url}),
+            matchers.header_matcher({"If-None-Match": '"v1"'}),
+        ],
+    )
+    responses.get(
+        INVENTORY_ENDPOINT,
+        body=_make_inventory(),
+        status=200,
+        content_type="application/octet-stream",
+        headers={"ETag": '"v1"'},
+        match=[matchers.query_param_matcher({"url": origin_inv_url})],
+    )
+
+    app1 = _make_app(make_app, app_params)
+    app1.build()
+
+    app2 = _make_app(make_app, app_params)
+    app2.build()
+
+    # The build succeeds and the fallback is reported at info level (not a
+    # warning, so a warnings-as-errors ``-W`` build does not fail), naming the
+    # inventory. The mapping entry is left untouched (its inventory location
+    # is still None), so stock intersphinx is responsible for the origin,
+    # exactly as without the service.
+    status = app2.status.getvalue()
+    assert "testproj" in status
+    assert "Could not prefetch" in status
+    assert "Could not prefetch" not in app2.warning.getvalue()
+    assert _inventory_locations(app2, "testproj") == (None,)
+
+
 @pytest.mark.sphinx(
     "html",
     testroot="intersphinx-cache-multi",

--- a/tests/ext/intersphinxcache_test.py
+++ b/tests/ext/intersphinxcache_test.py
@@ -209,6 +209,88 @@ def test_ttl_zero_revalidates_every_build(
     assert len(responses.calls) == 2
 
 
+@pytest.mark.sphinx(
+    "html",
+    testroot="intersphinx-cache",
+    srcdir="intersphinx-cache-log-download",
+)
+def test_download_logged_at_info(
+    make_app: Any,
+    app_params: Any,
+    responses: RequestsMock,
+    monkeypatch: Any,
+) -> None:
+    """A successful cold download from Ook is reported at info level naming
+    the inventory, so build logs show that the Ook cache was used (rather
+    than the prefetch being silent and only intersphinx's local-file loading
+    lines appearing).
+    """
+    monkeypatch.setenv("OOK_TOKEN", "test-token")
+    origin_inv_url = "https://example.com/project/objects.inv"
+    inventory = _make_inventory()
+    responses.get(
+        INVENTORY_ENDPOINT,
+        body=inventory,
+        status=200,
+        content_type="application/octet-stream",
+        match=[matchers.query_param_matcher({"url": origin_inv_url})],
+    )
+
+    app = _make_app(make_app, app_params)
+    app.build()
+
+    # The download is reported at info level (status stream, not the warning
+    # stream, so a warnings-as-errors ``-W`` build is unaffected), naming the
+    # inventory and the byte count.
+    status = app.status.getvalue()
+    assert (
+        "Downloaded the intersphinx inventory for 'testproj' from Ook "
+        f"({len(inventory)} bytes)." in status
+    )
+    assert "Downloaded" not in app.warning.getvalue()
+
+
+@pytest.mark.sphinx(
+    "html",
+    testroot="intersphinx-cache",
+    srcdir="intersphinx-cache-log-fastpath",
+)
+def test_ttl_fast_path_logged_at_info(
+    make_app: Any,
+    app_params: Any,
+    responses: RequestsMock,
+    monkeypatch: Any,
+) -> None:
+    """A TTL fast-path reuse (no request to Ook) is reported at info level
+    naming the inventory, so build logs distinguish a cache hit from the
+    extension not running at all.
+    """
+    monkeypatch.setenv("OOK_TOKEN", "test-token")
+    origin_inv_url = "https://example.com/project/objects.inv"
+    responses.get(
+        INVENTORY_ENDPOINT,
+        body=_make_inventory(),
+        status=200,
+        content_type="application/octet-stream",
+        match=[matchers.query_param_matcher({"url": origin_inv_url})],
+    )
+
+    # The first build downloads and writes the on-disk cache.
+    app1 = _make_app(make_app, app_params)
+    app1.build()
+
+    # The second build (within the default TTL) reuses the on-disk copy and
+    # says so at info level (status stream, not the warning stream).
+    app2 = _make_app(make_app, app_params)
+    app2.build()
+    status = app2.status.getvalue()
+    assert (
+        "Reusing the on-disk intersphinx inventory for 'testproj' "
+        "(younger than disk_cache_ttl)." in status
+    )
+    assert "Reusing" not in app2.warning.getvalue()
+
+
 def _etag_sidecar(inv_path: Path) -> Path:
     """Return the ETag sidecar path for a cached ``.inv`` file."""
     return inv_path.with_name(inv_path.name + ".etag")
@@ -274,6 +356,59 @@ def test_revalidation_304_reuses_disk_bytes(
     assert Path(locations[0]) == inv_path
     assert inv_path.read_bytes() == inventory
     assert sidecar.read_text() == etag
+
+
+@pytest.mark.sphinx(
+    "html",
+    testroot="intersphinx-cache",
+    srcdir="intersphinx-cache-log-304",
+    confoverrides={"documenteer_intersphinx_cache_disk_cache_ttl": 0},
+)
+def test_revalidation_304_logged_at_info(
+    make_app: Any,
+    app_params: Any,
+    responses: RequestsMock,
+    monkeypatch: Any,
+) -> None:
+    """A revalidation answered with 304 Not Modified is reported at info
+    level naming the inventory, so build logs show that Ook was consulted
+    and the on-disk copy is current.
+    """
+    monkeypatch.setenv("OOK_TOKEN", "test-token")
+    origin_inv_url = "https://example.com/project/objects.inv"
+    etag = '"v1etag"'
+    # The 304 (registered first) is chosen only when If-None-Match is sent;
+    # the initial build has no such header and falls through to the 200.
+    responses.get(
+        INVENTORY_ENDPOINT,
+        status=304,
+        match=[
+            matchers.query_param_matcher({"url": origin_inv_url}),
+            matchers.header_matcher({"If-None-Match": etag}),
+        ],
+    )
+    responses.get(
+        INVENTORY_ENDPOINT,
+        body=_make_inventory(),
+        status=200,
+        content_type="application/octet-stream",
+        headers={"ETag": etag},
+        match=[matchers.query_param_matcher({"url": origin_inv_url})],
+    )
+
+    app1 = _make_app(make_app, app_params)
+    app1.build()
+
+    # The second build revalidates, gets a 304, and says so at info level
+    # (status stream, not the warning stream).
+    app2 = _make_app(make_app, app_params)
+    app2.build()
+    status = app2.status.getvalue()
+    assert (
+        "The intersphinx inventory for 'testproj' is unchanged on Ook "
+        "(HTTP 304 Not Modified); reusing the on-disk copy." in status
+    )
+    assert "unchanged on Ook" not in app2.warning.getvalue()
 
 
 @pytest.mark.sphinx(

--- a/tests/storage/intersphinxcacheclient_test.py
+++ b/tests/storage/intersphinxcacheclient_test.py
@@ -9,7 +9,7 @@ import pytest
 import pytest_responses  # noqa: F401
 from requests.exceptions import ConnectionError as RequestsConnectionError
 from requests.exceptions import Timeout as RequestsTimeout
-from responses import RequestsMock
+from responses import RequestsMock, matchers
 
 from documenteer.storage.intersphinxcacheclient import (
     IntersphinxCacheClient,
@@ -42,15 +42,64 @@ def test_get_inventory_success(
     )
 
     client = IntersphinxCacheClient()
-    content = client.get_inventory(INVENTORY_URL)
+    result = client.get_inventory(INVENTORY_URL)
 
-    assert content == INVENTORY_BYTES
+    assert result.not_modified is False
+    assert result.content == INVENTORY_BYTES
+    assert result.etag is None
     assert len(responses.calls) == 1
     api_request = responses.calls[0].request
     assert api_request.headers["Authorization"] == "Bearer test-token"
+    assert "If-None-Match" not in api_request.headers
     assert api_request.url is not None
     query = parse_qs(urlparse(api_request.url).query)
     assert query["url"] == [INVENTORY_URL]
+
+
+def test_get_inventory_returns_etag(
+    responses: RequestsMock, monkeypatch: Any
+) -> None:
+    """A 200 response with an ETag header surfaces the ETag alongside the
+    inventory bytes.
+    """
+    monkeypatch.setenv("OOK_TOKEN", "test-token")
+    responses.get(
+        f"{BASE_URL}/intersphinx/inventory",
+        body=INVENTORY_BYTES,
+        status=200,
+        content_type="application/octet-stream",
+        headers={"ETag": '"abc123"'},
+    )
+
+    client = IntersphinxCacheClient()
+    result = client.get_inventory(INVENTORY_URL)
+
+    assert result.not_modified is False
+    assert result.content == INVENTORY_BYTES
+    assert result.etag == '"abc123"'
+
+
+def test_get_inventory_conditional_not_modified(
+    responses: RequestsMock, monkeypatch: Any
+) -> None:
+    """Passing an ETag sends ``If-None-Match``; a 304 response signals
+    not-modified with no body and echoes the requested ETag back.
+    """
+    monkeypatch.setenv("OOK_TOKEN", "test-token")
+    responses.get(
+        f"{BASE_URL}/intersphinx/inventory",
+        status=304,
+        match=[matchers.header_matcher({"If-None-Match": '"abc123"'})],
+    )
+
+    client = IntersphinxCacheClient()
+    result = client.get_inventory(INVENTORY_URL, etag='"abc123"')
+
+    assert result.not_modified is True
+    assert result.content is None
+    assert result.etag == '"abc123"'
+    api_request = responses.calls[0].request
+    assert api_request.headers["If-None-Match"] == '"abc123"'
 
 
 def test_missing_token(monkeypatch: Any) -> None:
@@ -142,8 +191,8 @@ def test_base_url_override(responses: RequestsMock, monkeypatch: Any) -> None:
     client = IntersphinxCacheClient(
         base_url="https://roundtable-dev.lsst.cloud/ook/"
     )
-    content = client.get_inventory(INVENTORY_URL)
-    assert content == INVENTORY_BYTES
+    result = client.get_inventory(INVENTORY_URL)
+    assert result.content == INVENTORY_BYTES
 
 
 def test_explicit_token_argument(
@@ -158,8 +207,8 @@ def test_explicit_token_argument(
     )
 
     client = IntersphinxCacheClient(token="explicit-token")
-    content = client.get_inventory(INVENTORY_URL)
+    result = client.get_inventory(INVENTORY_URL)
 
-    assert content == INVENTORY_BYTES
+    assert result.content == INVENTORY_BYTES
     api_request = responses.calls[0].request
     assert api_request.headers["Authorization"] == "Bearer explicit-token"

--- a/tests/test_conf_toml.py
+++ b/tests/test_conf_toml.py
@@ -292,3 +292,22 @@ def test_intersphinx_cache_settings() -> None:
         == "https://roundtable-dev.lsst.cloud/ook"
     )
     assert config.intersphinx_cache_disk_cache_ttl == 0
+
+
+EXAMPLE_NEGATIVE_TTL = """
+
+[project]
+title = "Documenteer"
+base_url = "https://documenteer.lsst.io"
+
+[sphinx.intersphinx_cache]
+disk_cache_ttl = -1
+"""
+
+
+def test_intersphinx_cache_negative_ttl_rejected() -> None:
+    """A negative disk_cache_ttl is rejected at config load rather than
+    silently coerced to the fast-path-disabled behavior of 0.
+    """
+    with pytest.raises(ConfigError):
+        DocumenteerConfig.load(EXAMPLE_NEGATIVE_TTL)

--- a/tests/test_conf_toml.py
+++ b/tests/test_conf_toml.py
@@ -265,6 +265,7 @@ base_url = "https://documenteer.lsst.io"
 [sphinx.intersphinx_cache]
 use_service = false
 service_url = "https://roundtable-dev.lsst.cloud/ook"
+disk_cache_ttl = 0
 """
 
 
@@ -279,6 +280,7 @@ def test_intersphinx_cache_defaults() -> None:
             config.intersphinx_cache_service_url
             == "https://roundtable.lsst.cloud/ook"
         )
+        assert config.intersphinx_cache_disk_cache_ttl == 600
 
 
 def test_intersphinx_cache_settings() -> None:
@@ -289,3 +291,4 @@ def test_intersphinx_cache_settings() -> None:
         config.intersphinx_cache_service_url
         == "https://roundtable-dev.lsst.cloud/ook"
     )
+    assert config.intersphinx_cache_disk_cache_ttl == 0


### PR DESCRIPTION
## Summary

- Avoid re-downloading intersphinx inventories from Ook on every build by caching them under the build tree with a short on-disk TTL, so rapid successive local rebuilds reuse the cached `.inv` files without any Ook round-trip.
- Add a `[sphinx.intersphinx_cache] disk_cache_ttl` setting (integer seconds, default `600`; `0` disables the fast path and forces revalidation each build), wired through `IntersphinxCacheModel`, the `DocumenteerConfig` accessors, the extension config value, and both presets.
- Add ETag-conditional revalidation: when the TTL has expired and a cached inventory plus its `<name>-<hash>.inv.etag` sidecar exist, the extension revalidates with `If-None-Match`. A `304 Not Modified` reuses the on-disk bytes (no body transferred, mtime refreshed to restart the TTL window); a `200` replaces both the `.inv` file and its sidecar; a `200` without an ETag clears any stale sidecar, preserving today's full-download behavior against older Ook servers.
- Preserve all existing graceful-degradation guarantees: `OOK_TOKEN` unset or `use_service = false` still no-ops completely, and any client error or cache-write failure leaves the mapping entry untouched with an INFO-level log so the build is never worse than without the service.
- Report each cache success path at INFO in the build log (cold download from Ook with byte count, TTL fast-path reuse, and 304-revalidation reuse), so logs show whether and how the Ook cache was used rather than only intersphinx's local-file loading lines.
- Document the `disk_cache_ttl` setting and the TTL fast path / ETag revalidation behavior in the `[sphinx.intersphinx_cache]` section of the TOML reference, plus a changelog fragment.

## Validation steps

- Build a docs site twice within `disk_cache_ttl` with a mocked Ook and confirm the second build makes zero requests to Ook while the mapping still resolves from the local cache files.
- Set `disk_cache_ttl = 0` and confirm every build contacts Ook; confirm the default is 600 and that the setting round-trips from `documenteer.toml` through `IntersphinxCacheModel` and both presets.
- After the TTL expires, confirm a revalidation returning `304` reuses the on-disk bytes (no body transferred, mtime refreshed) and rewrites the mapping to the local file; confirm a `200` replaces both the `.inv` file and the ETag sidecar.
- Against a server that returns no ETag, confirm behavior is byte-for-byte today's (full fetch on each TTL miss) with no errors or warnings, and that a `200` without an ETag clears any stale sidecar.
- Confirm a client error during revalidation leaves the mapping entry untouched with an INFO log and the build still succeeds; confirm `OOK_TOKEN` unset and `use_service = false` still no-op.
- Confirm the build log reports each success path at INFO: “Downloaded the intersphinx inventory … from Ook (N bytes)” on a cold fetch, “Reusing the on-disk intersphinx inventory …” within the TTL, and “… unchanged on Ook (HTTP 304 Not Modified)” on revalidation — with nothing added to the warning stream.
- Build the docs (`nox -s docs`) and confirm the new `disk_cache_ttl` documentation renders and the `[sphinx.intersphinx_cache]` cross-reference resolves.

## References

- Closes #347
- Closes #348
- Closes #349
- PRD: #342
- Jira: https://rubinobs.atlassian.net/browse/DM-55600
