### PR TITLE
DM-55493: Refresh vendored ruff-shared.toml for ruff 0.16 CPY001

### DIFF
--- a/ruff-shared.toml
+++ b/ruff-shared.toml
@@ -36,6 +36,7 @@ ignore = [
     "ASYNC240", # we don't want to run filesystem operations on threads
     "BLE001",   # we want to catch and report Exception in background tasks
     "C414",     # nested sorted is how you sort by multiple keys with reverse
+    "CPY001",   # No, every single file doesn't need its own copyright notice
     "D102",     # sometimes we use docstring inheritence
     "D104",     # don't see the point of documenting every package
     "D105",     # our style doesn't require docstrings for magic methods


### PR DESCRIPTION
## Summary

- Refreshes the vendored `ruff-shared.toml` from the `project_templates/square_pypi_package` template in lsst/templates, picking up the single-line change from [lsst/templates@dd8e4b26](https://github.com/lsst/templates/commit/dd8e4b26): ruff 0.16.0 stabilized `CPY001` (missing-copyright-notice) out of preview, and since `ruff-shared.toml` uses `select = ["ALL"]`, the rule armed itself fleet-wide. The template adds `CPY001` to the `[lint] ignore` list; this PR syncs documenteer's vendored copy to match, verbatim.
- No repo-specific `pyproject.toml` `[tool.ruff.*]` settings needed adjustment — `known-first-party` and other overrides remain in place and are not redundant with the refreshed shared file.

## Notes

- `ruff check .` at the repo's pinned pre-commit rev (`v0.15.20`) passes cleanly.
- `ruff check .` at latest ruff (0.16.0) surfaces 7 pre-existing `PLR0917` (too-many-positional-arguments) findings in `src/documenteer/ext/jira.py`, `src/documenteer/ext/lsstdocushare.py`, and `src/documenteer/ext/mockcoderefs.py` — another rule ruff 0.16.0 stabilized out of preview. This is out of scope for this config-only PR; no source changes were made and no local ignore was added, since a local ignore would make the vendored file diverge from the template and defeat the purpose of this migration.

Jira: [DM-55493](https://rubinobs.atlassian.net/browse/DM-55493)

[DM-55493]: https://rubinobs.atlassian.net/browse/DM-55493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ