### PR TITLE
DM-55634: Backport the Edit on GitHub source-directory fix to 2.4

### DIFF
--- a/changelog.d/20260727_000000_jonathan_DM_55634_github_edit_link_path.md
+++ b/changelog.d/20260727_000000_jonathan_DM_55634_github_edit_link_path.md
@@ -1,0 +1,5 @@
+### Bug fixes
+
+- The "Edit on GitHub" button now links to the correct file. The in-repository path is resolved from the Sphinx **source** directory rather than the directory containing `conf.py`, so projects that build with `sphinx-build -c . docs _build/html` (where those two directories differ) no longer produce links that 404. Projects whose source directory is the repository root also no longer get a stray `./` in the URL. This path is computed by a new `documenteer.ext.githubeditlink` extension, which the user-guide preset enables automatically.
+
+- Building a user guide outside a Git checkout — from an sdist, or in a Docker image built without the `.git` directory — no longer fails at configuration time with `InvalidGitRepositoryError`. The "Edit on GitHub" button is omitted instead and the build proceeds, so setting `show_github_edit_link = false` is no longer needed to work around this. Note that such a build still draws a `git.subprocess_error` warning from sphinx-last-updated-by-git (loaded through sphinx-sitemap), so a project that builds with `-W` also needs `suppress_warnings = ["git.subprocess_error"]` in `conf.py`.

--- a/docs/guides/toml-reference.rst
+++ b/docs/guides/toml-reference.rst
@@ -426,6 +426,17 @@ This configuration requires information about the GitHub repository from these o
 - :ref:`project.github_url <guide-project-github-url>`
 - :ref:`project.github_default_branch <guide-project-github-default-branch>`
 
+.. seealso::
+
+   :doc:`/sphinx-extensions/github-edit-link` for how the edit URL is assembled.
+
+The in-repository path of the documentation is detected automatically from where the Sphinx **source** directory sits in the Git working tree, so there is nothing to configure for it.
+Builds that keep :file:`conf.py` outside the source directory — ``sphinx-build -c . docs _build/html``, for instance — link to the right file.
+
+When the documentation isn't being built from a Git checkout (an sdist, or a Docker image built without the :file:`.git` directory) the path can't be determined, so the button is omitted from every page — noted in the build log at the informational level — and the build proceeds.
+Such a build does still draw a ``git.subprocess_error`` warning from sphinx-last-updated-by-git, so if you build with ``-W`` see :doc:`/sphinx-extensions/github-edit-link` for the warning to suppress.
+To keep the button in that situation, set the path yourself with ``html_context["doc_path"]`` in :file:`conf.py`; see :doc:`/sphinx-extensions/github-edit-link`.
+
 .. _guide-project-show-last-updated:
 
 show_last_updated

--- a/docs/sphinx-extensions/github-edit-link.rst
+++ b/docs/sphinx-extensions/github-edit-link.rst
@@ -1,0 +1,113 @@
+.. _documenteer-ext-githubeditlink:
+
+######################
+"Edit on GitHub" links
+######################
+
+Documenteer's ``documenteer.ext.githubeditlink`` extension resolves the in-repository path that pydata-sphinx-theme's "Edit on GitHub" button links to.
+It determines where the Sphinx **source** directory sits inside the Git working tree and publishes that path as the ``doc_path`` value in the HTML context.
+
+.. tip::
+
+   If you use Documenteer's user-guide configuration preset, this extension is already enabled and the button is shown by default.
+   Toggle it with the :ref:`show_github_edit_link <guide-project-show-github-edit-link>` setting in :file:`documenteer.toml`; you don't need to edit :file:`conf.py`.
+
+How the edit URL is built
+=========================
+
+pydata-sphinx-theme assembles the edit URL from several HTML context values:
+
+.. code-block:: text
+
+   {github_url}/{github_user}/{github_repo}/edit/{github_version}/{doc_path}{file_name}
+
+The user-guide preset fills in ``github_user``, ``github_repo``, and ``github_version`` from the :ref:`project.github_url <guide-project-github-url>` and :ref:`project.github_default_branch <guide-project-github-default-branch>` settings in :file:`documenteer.toml`.
+
+``file_name`` is supplied by the theme as the page's document name plus its source suffix — for example :file:`index.rst`.
+That name is relative to the Sphinx **source** directory, so ``doc_path`` has to be the source directory's own path within the Git working tree for the two halves to join into a real file path.
+This extension computes that path.
+
+Why an extension rather than :file:`conf.py`
+============================================
+
+The rest of the "Edit on GitHub" context is assembled while :file:`conf.py` is executed, but ``doc_path`` cannot be.
+At that moment there is no Sphinx application yet, and therefore no source directory to consult; the only path available is the current working directory, which Sphinx sets to the directory holding :file:`conf.py` — the *configuration* directory.
+
+For many projects the configuration and source directories are the same, and the distinction doesn't matter.
+They differ whenever a build passes ``-c``:
+
+.. code-block:: shell
+
+   sphinx-build -b html -c . docs _build/html
+
+Here the configuration directory is the repository root while the source directory is :file:`docs/`.
+A ``doc_path`` taken from the configuration directory would produce a URL that looks plausible but points at a file that doesn't exist.
+
+This extension therefore computes ``doc_path`` from the source directory at Sphinx's ``config-inited`` event — the earliest point where the source directory is known.
+That is also the safest point at which to *switch the button off*, because a theme may copy ``html_theme_options`` when the builder initializes, and a change made after that copy wouldn't reach the template.
+
+Overriding the detected path
+============================
+
+Auto-detection covers every layout Rubin projects are known to use, but you can set ``doc_path`` yourself in :file:`conf.py` to override it:
+
+.. code-block:: python
+   :caption: conf.py
+
+   html_context["doc_path"] = "docs"
+
+When ``doc_path`` is already set, the extension uses that value and doesn't consult Git at all.
+The button therefore keeps working outside a Git checkout — supplying the path answers the question that auto-detection would have used the working tree to answer.
+
+This is the escape hatch for source layouts that a path within the working tree can't describe, such as a generated source directory, or documentation published from a different repository than the one being built.
+
+Builds outside a Git checkout
+=============================
+
+The path can only be derived from a Git working tree.
+When the source directory isn't inside one — an sdist, a vendored documentation tree, or a Docker image built without the :file:`.git` directory — the extension omits the "Edit on GitHub" button from every page and notes this in the build log at the informational level.
+
+The message is deliberately *not* a warning: building outside a checkout is legitimate, and a warning would fail any build run with ``-W`` (which turns warnings into errors).
+
+.. note::
+
+   This extension stays quiet, but it isn't the only part of the user-guide stack that reads Git.
+   The preset also loads `sphinx-last-updated-by-git <https://github.com/mgeier/sphinx-last-updated-by-git>`__ (through sphinx-sitemap), which *does* warn when it can't read the history:
+
+   .. code-block:: text
+
+      WARNING: Error getting data from Git (no "last updated" dates will be shown
+      for source files from …): fatal: not a git repository [git.subprocess_error]
+
+   A project that builds with ``-W`` outside a Git checkout therefore needs to suppress that warning as well:
+
+   .. code-block:: python
+      :caption: conf.py
+
+      suppress_warnings = ["git.subprocess_error"]
+
+   Without ``-W`` the warning is harmless and the build succeeds either way.
+
+Reference
+=========
+
+The user-guide configuration preset enables this extension automatically.
+To use it in a standalone Sphinx project, add ``"documenteer.ext.githubeditlink"`` to the extensions list in :file:`conf.py` and provide the repository context that pydata-sphinx-theme expects:
+
+.. code-block:: python
+   :caption: conf.py
+
+   extensions = ["documenteer.ext.githubeditlink", ...]
+
+   html_theme = "pydata_sphinx_theme"
+   html_theme_options = {
+       "use_edit_page_button": True,
+   }
+   html_context = {
+       "github_user": "lsst-sqre",
+       "github_repo": "documenteer",
+       "github_version": "main",
+   }
+
+The extension fills in ``doc_path`` itself, so you don't need to provide it — but it honors the value if you do (see `Overriding the detected path`_).
+It takes no configuration of its own, and is inert unless ``use_edit_page_button`` is enabled.

--- a/docs/sphinx-extensions/index.rst
+++ b/docs/sphinx-extensions/index.rst
@@ -26,3 +26,4 @@ Sphinx extensions
    :caption: Page metadata
 
    last-updated
+   github-edit-link

--- a/src/documenteer/conf/_toml.py
+++ b/src/documenteer/conf/_toml.py
@@ -25,8 +25,6 @@ from pydantic import (
 )
 from sphinx.errors import ConfigError
 
-from ._utils import GitRepository
-
 __all__ = [
     "ConfigRoot",
     "DocumenteerConfig",
@@ -519,7 +517,13 @@ class DocumenteerConfig:
         html_theme_options: MutableMapping[str, Any],
         html_context: MutableMapping[str, Any],
     ) -> None:
-        """Configure the Edit on GitHub functionality, if possible."""
+        """Configure the Edit on GitHub functionality, if possible.
+
+        The in-repository path of the documentation source is *not* set here;
+        it is resolved from the Sphinx source directory by the
+        ``documenteer.ext.githubeditlink`` extension, which is the earliest
+        point where the source directory is known.
+        """
         if (
             self.conf.sphinx
             and self.conf.sphinx.theme.show_github_edit_link is False
@@ -528,7 +532,7 @@ class DocumenteerConfig:
 
         if self.github_url is None:
             raise ConfigError(
-                "sphinx.show_github_edit_link is True by the "
+                "sphinx.show_github_edit_link is True but the "
                 "project.github_url is not set."
             )
 
@@ -543,26 +547,12 @@ class DocumenteerConfig:
                 f"Could not parse GitHub repo URL: {self.github_url}"
             ) from e
 
-        repo = GitRepository(Path.cwd())
-        try:
-            # the current working directory for sphinx config is always
-            # the same as the directory containing the conf.py file.
-            doc_dir = str(Path.cwd().relative_to(repo.working_tree_dir))
-        except ValueError as e:
-            raise ConfigError(
-                "Cannot determine the path of the documentation directory "
-                "relative to the Git repository root. Set "
-                "sphinx.show_github_edit_link to false if this is not a "
-                "git repository."
-            ) from e
-
         html_theme_options["use_edit_page_button"] = True
         html_context["github_user"] = github_owner
         html_context["github_repo"] = github_repo
         html_context["github_version"] = (
             self.conf.project.github_default_branch
         )
-        html_context["doc_path"] = doc_dir
 
     @property
     def header_links_before_dropdown(self) -> int:

--- a/src/documenteer/conf/_utils.py
+++ b/src/documenteer/conf/_utils.py
@@ -122,6 +122,39 @@ class GitRepository:
             raise RuntimeError("Git repository is not available.")
         return Path(path)
 
+    def compute_relative_path(self, path: Path | str) -> str | None:
+        """Compute the path of a directory relative to the repository root.
+
+        Parameters
+        ----------
+        path
+            A path inside the Git working tree.
+
+        Returns
+        -------
+        str or None
+            The POSIX-style path of ``path`` relative to the root of the Git
+            working tree. The empty string is returned when ``path`` *is* the
+            repository root (`pathlib.Path.relative_to` yields ``"."`` there,
+            which would inject a literal ``./`` into a URL built from this
+            value). `None` is returned when ``path`` lies outside the working
+            tree.
+
+        Notes
+        -----
+        Both the repository root and ``path`` are resolved before they are
+        compared, so a symlinked path (such as macOS's :file:`/tmp`, which
+        links to :file:`/private/tmp`) is still recognized as being inside the
+        working tree.
+        """
+        root = self.working_tree_dir.resolve()
+        try:
+            relative = Path(path).resolve().relative_to(root)
+        except ValueError:
+            return None
+        posix = relative.as_posix()
+        return "" if posix == "." else posix
+
     @property
     def is_shallow(self) -> bool:
         """Whether the repository is a shallow clone.

--- a/src/documenteer/conf/guide.py
+++ b/src/documenteer/conf/guide.py
@@ -172,6 +172,7 @@ extensions = [
     "sphinx_sitemap",
     "documenteer.ext.robots",
     "documenteer.ext.lastmodified",
+    "documenteer.ext.githubeditlink",
     "documenteer.ext.jira",
     "documenteer.ext.lsstdocushare",
     "documenteer.ext.mockcoderefs",

--- a/src/documenteer/ext/githubeditlink.py
+++ b/src/documenteer/ext/githubeditlink.py
@@ -1,0 +1,147 @@
+"""Sphinx extension that resolves the in-repository path used by the "Edit on
+GitHub" button.
+
+pydata-sphinx-theme builds the edit URL as::
+
+    {github_url}/{github_user}/{github_repo}/edit/{github_version}/{doc_path}{file_name}
+
+where ``file_name`` is the page's docname plus its source suffix — a path
+relative to the Sphinx **source** directory. ``doc_path`` must therefore be the
+*source* directory's path within the Git working tree.
+
+That value cannot be computed in :file:`conf.py`, which is where the rest of
+the "Edit on GitHub" context is set. At ``conf.py`` exec time there is no
+Sphinx application and hence no ``srcdir``; the only path available is the
+current working directory, which Sphinx sets to the directory containing
+``conf.py`` (the *config* directory). Those two directories are the same in
+many projects, but not all: ``sphinx-build -c . docs _build/html`` puts the
+config directory at the repository root and the source directory in
+:file:`docs/`. Deriving ``doc_path`` from the config directory there yields a
+plausible-looking URL that 404s.
+
+This extension therefore computes ``doc_path`` from ``app.srcdir`` at
+``config-inited``, the earliest event where the source directory is known.
+That is also the safest event for *disabling* the button: ``builder.init()``
+runs before ``builder-inited`` is emitted, and a theme may take its own copy of
+``html_theme_options`` there rather than reading the live config, in which case
+a later change wouldn't reach the template. (pydata-sphinx-theme's
+``get_theme_options_dict`` documents exactly that "sometimes the copy never
+occurs" ambiguity.) Settling it at ``config-inited`` avoids depending on which
+behavior a given Sphinx or theme version has.
+
+Ordering against pydata-sphinx-theme needs no special handling: that theme
+connects its own handlers to ``builder-inited`` and ``html-page-context``, and
+does nothing at ``config-inited``.
+
+Outside a Git checkout (an sdist, a vendored documentation tree, a Docker image
+built without :file:`.git`) the path can't be determined, so the button is
+silently omitted rather than rendered with a wrong path.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import git
+from sphinx.application import Sphinx
+from sphinx.config import Config
+from sphinx.util import logging
+from sphinx.util.typing import ExtensionMetadata
+
+from ..conf._utils import GitRepository
+from ..version import __version__
+
+__all__ = ["set_doc_path", "setup"]
+
+logger = logging.getLogger(__name__)
+
+
+def _disable_edit_button(config: Config) -> None:
+    """Suppress the "Edit on GitHub" button for this build.
+
+    Turning off ``use_edit_page_button`` is sufficient: pydata-sphinx-theme's
+    ``edit-this-page`` component is gated on the resulting
+    ``theme_use_edit_page_button`` template variable, so the theme never tries
+    to build an edit URL (and never raises for the missing context).
+    """
+    config.html_theme_options["use_edit_page_button"] = False
+    # Drop any stale value so a leftover path can't leak into the context.
+    config.html_context.pop("doc_path", None)
+
+
+def set_doc_path(app: Sphinx, config: Config) -> None:
+    """Set ``html_context["doc_path"]`` from the source directory's location
+    in the Git working tree.
+
+    Parameters
+    ----------
+    app
+        The Sphinx application. Its ``srcdir`` is already resolved by Sphinx.
+    config
+        The Sphinx configuration, modified in place.
+    """
+    if not config.html_theme_options.get("use_edit_page_button"):
+        # Presets that don't use the edit button (such as the technote preset)
+        # leave this extension inert.
+        return
+
+    if "doc_path" in config.html_context:
+        # An explicitly-configured path wins. This handler runs *after*
+        # conf.py, so without this an author could never override the
+        # auto-detected value. It is the escape hatch for the layouts a
+        # working-tree path can't describe: a generated source directory, or
+        # documentation published from a repository other than the one being
+        # built.
+        logger.debug(
+            "documenteer.ext.githubeditlink: using the configured doc_path "
+            "%r; skipping auto-detection.",
+            config.html_context["doc_path"],
+        )
+        return
+
+    try:
+        repo = GitRepository(Path(app.srcdir))
+    except (git.InvalidGitRepositoryError, git.NoSuchPathError):
+        # Deliberately info, not warning: Rubin projects build with ``-W``, and
+        # building outside a Git checkout is legitimate, so a warning would
+        # turn a cosmetic degradation into a build failure. (This also diverges
+        # from documenteer.ext.lastmodified, which logs at debug; this message
+        # explains a *missing* UI element, so it's worth showing by default.)
+        logger.info(
+            "documenteer.ext.githubeditlink: %s is not in a Git repository; "
+            "omitting the 'Edit on GitHub' button.",
+            app.srcdir,
+        )
+        _disable_edit_button(config)
+        return
+
+    doc_path = repo.compute_relative_path(app.srcdir)
+    if doc_path is None:
+        # A repository was found from the source directory, yet the source
+        # directory isn't inside its working tree. Both paths are resolved, so
+        # this shouldn't be reachable in a normal checkout; warn because it
+        # signals a genuinely odd setup (a bind mount, say) rather than the
+        # expected non-Git case.
+        logger.warning(
+            "documenteer.ext.githubeditlink: could not determine the path of "
+            "%s relative to the Git working tree at %s; omitting the 'Edit on "
+            "GitHub' button.",
+            app.srcdir,
+            repo.working_tree_dir,
+        )
+        _disable_edit_button(config)
+        return
+
+    config.html_context["doc_path"] = doc_path
+
+
+def setup(app: Sphinx) -> ExtensionMetadata:
+    """Set up the ``documenteer.ext.githubeditlink`` Sphinx extension."""
+    app.connect("config-inited", set_doc_path)
+
+    return {
+        "version": __version__,
+        # The handler runs once, at config-inited, in the main process.
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/tests/ext/conftest.py
+++ b/tests/ext/conftest.py
@@ -1,0 +1,24 @@
+"""Shared fixtures for the documenteer.ext test suite."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _fresh_guide_config_module() -> None:
+    """Drop the cached guide config module before each test.
+
+    ``documenteer.conf.guide`` computes all of its Sphinx settings at import
+    time from the ``documenteer.toml`` in the current working directory. Once
+    a test root's ``conf.py`` runs ``from documenteer.conf.guide import *``,
+    Python caches the module in ``sys.modules``, so a *second* test root that
+    builds the guide stack in the same pytest process would re-bind the first
+    root's already-computed settings instead of reading its own
+    ``documenteer.toml``. Evicting the module here makes every guide-stack
+    build re-import it against its own config. The pop is a no-op for tests
+    that never import the module.
+    """
+    sys.modules.pop("documenteer.conf.guide", None)

--- a/tests/ext/githubeditlink_test.py
+++ b/tests/ext/githubeditlink_test.py
@@ -1,0 +1,379 @@
+# type: ignore
+"""Tests for documenteer.ext.githubeditlink.
+
+These builds drive ``sphinx.application.Sphinx`` directly rather than through
+the ``app`` fixture, because ``SphinxTestApp`` hardcodes ``confdir = srcdir``
+and the central case this extension exists for is precisely the build where
+they differ (``sphinx-build -c . docs …``).
+
+The whole module requires pydata-sphinx-theme: ``use_edit_page_button`` is that
+theme's option, so there is nothing to exercise without it.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+from io import StringIO
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import git
+import pytest
+from git import Actor, Repo
+from sphinx.application import Sphinx
+
+_HAS_PYDATA = importlib.util.find_spec("pydata_sphinx_theme") is not None
+
+pytestmark = pytest.mark.skipif(
+    not _HAS_PYDATA, reason="pydata_sphinx_theme is not installed"
+)
+
+CONF_PY = """\
+extensions = ["documenteer.ext.githubeditlink"]
+
+html_theme = "pydata_sphinx_theme"
+html_theme_options = {"use_edit_page_button": True}
+html_context = {
+    "github_user": "lsst",
+    "github_repo": "dp2_lsst_io",
+    "github_version": "main",
+}
+"""
+
+INDEX_RST = """\
+Test page
+=========
+
+Body text.
+"""
+
+# The URL pydata-sphinx-theme builds for the index page of the project
+# configured by CONF_PY, for a source directory in ``docs/``.
+DP2_INDEX_URL = "https://github.com/lsst/dp2_lsst_io/edit/main/docs/index.rst"
+
+# A documenteer.toml driving the real user-guide preset, whose github_url and
+# default github_default_branch ("main") produce DP2_INDEX_URL.
+GUIDE_TOML = """\
+[project]
+title = "Guide Preset Edit Link Test"
+base_url = "https://example.lsst.io"
+github_url = "https://github.com/lsst/dp2_lsst_io"
+"""
+
+GUIDE_CONF_PY = "from documenteer.conf.guide import *\n"
+
+ACTOR = Actor("Test Author", "test@example.com")
+
+
+# Constructing several ``Sphinx`` applications in one process re-runs the
+# setup() of Sphinx's own built-in extensions, which warns about every node,
+# directive, and role it re-registers. The pattern is anchored on that
+# re-setup of a ``sphinx.*`` extension, so it can only ever match this
+# artifact -- a warning from the build under test, or from Documenteer's own
+# extensions, still reaches the assertions.
+_REREGISTRATION_WARNING = re.compile(
+    r"while setting up extension sphinx\.[\w.]+:.*is already registered"
+)
+
+
+def _project_warnings(warning_output: str) -> list[str]:
+    """Filter a build's warning stream down to warnings about the project.
+
+    Drops the cross-application re-registration noise described on
+    `_REREGISTRATION_WARNING`, which is an artifact of the test process rather
+    than of the build under test.
+    """
+    return [
+        line
+        for line in warning_output.splitlines()
+        if line.strip() and not _REREGISTRATION_WARNING.search(line)
+    ]
+
+
+class _Build:
+    """The result of a completed Sphinx build."""
+
+    def __init__(self, app: Sphinx, warning_output: str) -> None:
+        self.app = app
+        self.warnings = _project_warnings(warning_output)
+
+    @property
+    def doc_path(self) -> str | None:
+        """The ``doc_path`` the extension set, or `None` if it set none."""
+        return self.app.config.html_context.get("doc_path")
+
+    @property
+    def use_edit_page_button(self) -> bool:
+        return self.app.config.html_theme_options["use_edit_page_button"]
+
+    @property
+    def index_html(self) -> str:
+        return (Path(self.app.outdir) / "index.html").read_text()
+
+
+def _write_project(*, confdir: Path, srcdir: Path) -> None:
+    """Write a minimal Sphinx project with the given config and source dirs.
+
+    The two directories may be the same or different; either way ``conf.py``
+    lands in ``confdir`` and ``index.rst`` in ``srcdir``.
+    """
+    confdir.mkdir(parents=True, exist_ok=True)
+    srcdir.mkdir(parents=True, exist_ok=True)
+    (confdir / "conf.py").write_text(CONF_PY)
+    (srcdir / "index.rst").write_text(INDEX_RST)
+
+
+def _build(*, confdir: Path, srcdir: Path, outdir: Path) -> _Build:
+    """Build a project with Sphinx, capturing its warning stream.
+
+    ``Sphinx.__init__`` emits ``config-inited``, so the extension has already
+    run by the time the application is constructed.
+    """
+    warning = StringIO()
+    app = Sphinx(
+        srcdir=str(srcdir),
+        confdir=str(confdir),
+        outdir=str(outdir),
+        doctreedir=str(outdir / ".doctrees"),
+        buildername="html",
+        status=StringIO(),
+        warning=warning,
+    )
+    app.build()
+    return _Build(app, warning.getvalue())
+
+
+def test_confdir_at_repo_root(tmp_path: Path) -> None:
+    """The dp2 layout: ``conf.py`` at the repo root, sources in ``docs/``.
+
+    This is ``sphinx-build -c . docs _build/html``. The edit URL must address
+    the *source* file, so ``doc_path`` is the source directory's path in the
+    working tree -- not the config directory's.
+    """
+    Repo.init(tmp_path)
+    _write_project(confdir=tmp_path, srcdir=tmp_path / "docs")
+
+    build = _build(
+        confdir=tmp_path, srcdir=tmp_path / "docs", outdir=tmp_path / "_build"
+    )
+
+    assert build.doc_path == "docs"
+    # End-to-end: the rendered link addresses docs/index.rst, not ./index.rst.
+    assert f'href="{DP2_INDEX_URL}"' in build.index_html
+
+
+def test_confdir_equals_srcdir_in_subdirectory(tmp_path: Path) -> None:
+    """Documenteer's own layout: ``docs/`` is both confdir and srcdir."""
+    Repo.init(tmp_path)
+    docs = tmp_path / "docs"
+    _write_project(confdir=docs, srcdir=docs)
+
+    build = _build(confdir=docs, srcdir=docs, outdir=tmp_path / "_build")
+
+    assert build.doc_path == "docs"
+    assert f'href="{DP2_INDEX_URL}"' in build.index_html
+
+
+def test_srcdir_at_repo_root(tmp_path: Path) -> None:
+    """A source directory at the repo root yields an empty ``doc_path``.
+
+    ``Path.relative_to`` reports ``"."`` for this case, which would put a
+    literal ``./`` into the URL.
+    """
+    Repo.init(tmp_path)
+    _write_project(confdir=tmp_path, srcdir=tmp_path)
+
+    build = _build(
+        confdir=tmp_path, srcdir=tmp_path, outdir=tmp_path / "_build"
+    )
+
+    assert build.doc_path == ""
+    assert (
+        'href="https://github.com/lsst/dp2_lsst_io/edit/main/index.rst"'
+        in build.index_html
+    )
+    assert "/edit/main/./" not in build.index_html
+
+
+def test_not_a_git_repository(tmp_path: Path) -> None:
+    """Outside a Git checkout the button is omitted without failing the build.
+
+    ``GitRepository`` is patched rather than relying on the temporary directory
+    being outside a checkout, so the test can't be perturbed by where pytest's
+    basetemp lives.
+    """
+    _write_project(confdir=tmp_path, srcdir=tmp_path / "docs")
+
+    with patch(
+        "documenteer.ext.githubeditlink.GitRepository",
+        side_effect=git.InvalidGitRepositoryError,
+    ):
+        build = _build(
+            confdir=tmp_path,
+            srcdir=tmp_path / "docs",
+            outdir=tmp_path / "_build",
+        )
+
+    assert build.use_edit_page_button is False
+    assert build.doc_path is None
+    assert "Edit on GitHub" not in build.index_html
+    # Nothing is logged at warning level, so builds using ``-W`` still pass.
+    assert build.warnings == []
+
+
+def test_srcdir_outside_working_tree(tmp_path: Path) -> None:
+    """A repo whose working tree excludes the srcdir warns and disables.
+
+    This shouldn't be reachable in a normal checkout -- both paths are
+    resolved before they're compared -- so unlike the plain non-Git case it is
+    treated as a genuine misconfiguration and does warn.
+    """
+    _write_project(confdir=tmp_path, srcdir=tmp_path / "docs")
+
+    mock_repo = MagicMock()
+    mock_repo.compute_relative_path.return_value = None
+    mock_repo.working_tree_dir = Path("/somewhere/else")
+
+    with patch(
+        "documenteer.ext.githubeditlink.GitRepository", return_value=mock_repo
+    ):
+        build = _build(
+            confdir=tmp_path,
+            srcdir=tmp_path / "docs",
+            outdir=tmp_path / "_build",
+        )
+
+    assert build.use_edit_page_button is False
+    assert build.doc_path is None
+    assert "Edit on GitHub" not in build.index_html
+    assert len(build.warnings) == 1
+    assert "could not determine the path" in build.warnings[0]
+
+
+def test_symlinked_srcdir(tmp_path: Path) -> None:
+    """A symlinked path to the project still resolves to the same doc path."""
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    Repo.init(repo_dir)
+    _write_project(confdir=repo_dir, srcdir=repo_dir / "docs")
+
+    link = tmp_path / "link"
+    link.symlink_to(repo_dir, target_is_directory=True)
+
+    build = _build(
+        confdir=link, srcdir=link / "docs", outdir=tmp_path / "_build"
+    )
+
+    assert build.doc_path == "docs"
+    assert f'href="{DP2_INDEX_URL}"' in build.index_html
+
+
+def test_guide_preset_dp2_layout(tmp_path: Path) -> None:
+    """The real user-guide preset produces a correct edit link, dp2-style.
+
+    This is the wiring test: it drives ``documenteer.conf.guide`` itself, so it
+    fails if the extension is dropped from the preset's extensions list or if
+    ``set_edit_on_github`` stops enabling the button -- neither of which the
+    hand-written ``conf.py`` cases above would notice.
+
+    The sources are committed because the guide preset auto-loads
+    sphinx-last-updated-by-git (through sphinx-sitemap), which deletes
+    ``sourcename`` from the context for files Git doesn't track. pydata's
+    edit-this-page component is gated on that value, so an *uncommitted* page
+    renders no button no matter what ``doc_path`` says.
+    """
+    repo = Repo.init(tmp_path)
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    paths = [
+        tmp_path / "documenteer.toml",
+        tmp_path / "conf.py",
+        docs / "index.rst",
+    ]
+    paths[0].write_text(GUIDE_TOML)
+    paths[1].write_text(GUIDE_CONF_PY)
+    paths[2].write_text(INDEX_RST)
+    repo.index.add([str(p) for p in paths])
+    repo.index.commit("Add docs", author=ACTOR, committer=ACTOR)
+
+    build = _build(confdir=tmp_path, srcdir=docs, outdir=tmp_path / "_build")
+
+    assert build.doc_path == "docs"
+    assert f'href="{DP2_INDEX_URL}"' in build.index_html
+
+
+def test_configured_doc_path_wins(tmp_path: Path) -> None:
+    """An explicitly-configured ``doc_path`` overrides auto-detection.
+
+    The handler runs after ``conf.py``, so without this the setting would be
+    impossible to override.
+    """
+    Repo.init(tmp_path)
+    _write_project(confdir=tmp_path, srcdir=tmp_path / "docs")
+    (tmp_path / "conf.py").write_text(
+        CONF_PY.replace(
+            '"github_version": "main",',
+            '"github_version": "main",\n    "doc_path": "custom/path",',
+        )
+    )
+
+    build = _build(
+        confdir=tmp_path, srcdir=tmp_path / "docs", outdir=tmp_path / "_build"
+    )
+
+    # "docs" is what auto-detection would have produced.
+    assert build.doc_path == "custom/path"
+    assert (
+        'href="https://github.com/lsst/dp2_lsst_io/edit/main/custom/path/index.rst"'
+        in build.index_html
+    )
+
+
+def test_configured_doc_path_survives_without_git(tmp_path: Path) -> None:
+    """A configured ``doc_path`` keeps the button outside a Git checkout.
+
+    Auto-detection is what needs a working tree; an author who supplied the
+    path has already answered the question Git would have.
+    """
+    _write_project(confdir=tmp_path, srcdir=tmp_path / "docs")
+    (tmp_path / "conf.py").write_text(
+        CONF_PY.replace(
+            '"github_version": "main",',
+            '"github_version": "main",\n    "doc_path": "custom/path",',
+        )
+    )
+
+    with patch(
+        "documenteer.ext.githubeditlink.GitRepository",
+        side_effect=git.InvalidGitRepositoryError,
+    ) as mock_repo:
+        build = _build(
+            confdir=tmp_path,
+            srcdir=tmp_path / "docs",
+            outdir=tmp_path / "_build",
+        )
+
+    # Git is never consulted at all when the path is already known.
+    mock_repo.assert_not_called()
+    assert build.doc_path == "custom/path"
+    assert build.use_edit_page_button is True
+    assert "Edit on GitHub" in build.index_html
+
+
+def test_inert_without_edit_page_button(tmp_path: Path) -> None:
+    """With the button off, the extension sets nothing (the technote case)."""
+    Repo.init(tmp_path)
+    _write_project(confdir=tmp_path, srcdir=tmp_path / "docs")
+    (tmp_path / "conf.py").write_text(
+        CONF_PY.replace(
+            '{"use_edit_page_button": True}', '{"use_edit_page_button": False}'
+        )
+    )
+
+    build = _build(
+        confdir=tmp_path, srcdir=tmp_path / "docs", outdir=tmp_path / "_build"
+    )
+
+    assert build.doc_path is None
+    assert "Edit on GitHub" not in build.index_html

--- a/tests/roots/test-redoc/documenteer.toml
+++ b/tests/roots/test-redoc/documenteer.toml
@@ -1,10 +1,8 @@
 [project]
 title = "Redoc Test"
 base_url = "https://example.lsst.io"
+github_url = "https://github.com/lsst-sqre/example"
 
 [project.openapi]
 openapi_path = "_static/openapi.json"
 doc_path = "api"
-
-[sphinx.theme]
-show_github_edit_link = false

--- a/tests/test_conf_toml.py
+++ b/tests/test_conf_toml.py
@@ -93,6 +93,17 @@ title = "Documenteer"
 copyright = "2022 AURA"
 """
 
+EXAMPLE_NO_GITHUB_EDIT_LINK = """
+
+[project]
+title = "Documenteer"
+copyright = "2022 AURA"
+github_url = "https://github.com/lsst-sqre/documenteer"
+
+[sphinx.theme]
+show_github_edit_link = false
+"""
+
 
 def test_load() -> None:
     config = DocumenteerConfig.load(EXAMPLE)
@@ -192,3 +203,39 @@ def test_show_last_updated_disabled() -> None:
     """show_last_updated reflects sphinx.theme.show_last_updated = false."""
     config = DocumenteerConfig.load(EXAMPLE_NO_LAST_UPDATED)
     assert config.show_last_updated is False
+
+
+def test_set_edit_on_github() -> None:
+    """The GitHub repository context is set, but not doc_path.
+
+    ``doc_path`` is resolved from the Sphinx source directory by
+    ``documenteer.ext.githubeditlink``, which can't run this early.
+    """
+    config = DocumenteerConfig.load(EXAMPLE)
+    html_theme_options: dict = {}
+    html_context: dict = {}
+    config.set_edit_on_github(html_theme_options, html_context)
+
+    assert html_theme_options["use_edit_page_button"] is True
+    assert html_context["github_user"] == "lsst-sqre"
+    assert html_context["github_repo"] == "documenteer"
+    assert html_context["github_version"] == "main"
+    assert "doc_path" not in html_context
+
+
+def test_set_edit_on_github_disabled() -> None:
+    """show_github_edit_link = false leaves the Sphinx settings untouched."""
+    config = DocumenteerConfig.load(EXAMPLE_NO_GITHUB_EDIT_LINK)
+    html_theme_options: dict = {}
+    html_context: dict = {}
+    config.set_edit_on_github(html_theme_options, html_context)
+
+    assert html_theme_options == {}
+    assert html_context == {}
+
+
+def test_set_edit_on_github_without_github_url() -> None:
+    """The edit link needs project.github_url to build a URL from."""
+    config = DocumenteerConfig.load(EXAMPLE_NO_SPHINX)
+    with pytest.raises(ConfigError, match=r"project\.github_url is not set"):
+        config.set_edit_on_github({}, {})

--- a/tests/test_git_repository.py
+++ b/tests/test_git_repository.py
@@ -1,4 +1,4 @@
-"""Tests for documenteer.conf._utils.GitRepository.compute_last_modified."""
+"""Tests for documenteer.conf._utils.GitRepository."""
 
 from __future__ import annotations
 
@@ -103,6 +103,50 @@ def test_path_outside_working_tree_skipped(tmp_path: Path) -> None:
     assert git_repo.compute_last_modified([page, outside]) == datetime(
         2024, 6, 1, tzinfo=UTC
     )
+
+
+def test_compute_relative_path(tmp_path: Path) -> None:
+    """Paths inside the working tree resolve to POSIX-style relative paths."""
+    Repo.init(tmp_path)
+    (tmp_path / "docs" / "guides").mkdir(parents=True)
+
+    git_repo = GitRepository(tmp_path)
+
+    # The repository root itself is the empty string, not "." (which would put
+    # a literal "./" into a URL built from this value).
+    assert git_repo.compute_relative_path(tmp_path) == ""
+
+    assert git_repo.compute_relative_path(tmp_path / "docs") == "docs"
+    assert (
+        git_repo.compute_relative_path(tmp_path / "docs" / "guides")
+        == "docs/guides"
+    )
+
+
+def test_compute_relative_path_outside_working_tree(tmp_path: Path) -> None:
+    """A path outside the working tree yields None."""
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    Repo.init(repo_dir)
+    sibling = tmp_path / "elsewhere"
+    sibling.mkdir()
+
+    git_repo = GitRepository(repo_dir)
+    assert git_repo.compute_relative_path(sibling) is None
+
+
+def test_compute_relative_path_through_symlink(tmp_path: Path) -> None:
+    """A symlinked alias of a directory resolves to its real relative path."""
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    Repo.init(repo_dir)
+    (repo_dir / "docs").mkdir()
+
+    link = tmp_path / "link"
+    link.symlink_to(repo_dir, target_is_directory=True)
+
+    git_repo = GitRepository(repo_dir)
+    assert git_repo.compute_relative_path(link / "docs") == "docs"
 
 
 def test_cache_reuse(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Backport of #352 onto the new `2.4` release branch, for a 2.4.x patch release.

- The "Edit on GitHub" button now resolves its in-repository path from the Sphinx **source** directory rather than the directory holding `conf.py`. Projects that build with `sphinx-build -c . docs _build/html` (where those differ) no longer emit links that 404 — this is what https://dp2.lsst.io/ hits today. A source directory at the repository root also no longer produces a stray `./`.
- The path is computed by a new `documenteer.ext.githubeditlink` extension at `config-inited`, the earliest event where `srcdir` is known. An explicitly configured `html_context["doc_path"]` is honored and short-circuits auto-detection.
- Building outside a Git checkout no longer raises `InvalidGitRepositoryError` at configuration time; the button is omitted instead.

## Backport adaptations

The `2.4` branch predates several things the original PR touched, so this is not a clean replay:

- `_toml.py` drops its `._utils` import entirely rather than narrowing it — `normalize_origin_base_url` and the storage clients don't exist on 2.4.
- The `test-guide` and `test-linkcheck-service*` roots don't exist yet, so only `test-redoc` is relaxed (and gains a `github_url`, since `show_github_edit_link` now defaults on).
- `tests/test_conf_toml.py` takes only the three `set_edit_on_github` guard tests; the link-check service cases belong to a later feature.
- `tests/ext/conftest.py` is brought along, because `tests/roots/test-redoc` also builds the guide preset — without the module-eviction fixture, the two guide-stack builds in one pytest process would share cached settings.

## Validation steps

Run against this branch's own tooling (2.4 uses tox, not nox):

```console
tox -e py-test-sphinx8    # 84 passed
tox -e typing-sphinx8     # clean
tox -e lint               # clean
tox -e docs               # builds, including the new extension page
```

All four pass locally. The suite includes the wiring test that drives the real guide preset in the `-c .`/`docs` layout, which was confirmed on `main` to fail if the extension is unregistered.

## References

- Backport of #352
- Jira: https://rubinobs.atlassian.net/browse/DM-55634