### PR TITLE
DM-55493: scope PLR0917 for ruff 0.16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,6 +221,13 @@ extend-ignore = [
 "src/documenteer/services/technotemigration.py" = [
     "T201",    # This script can use print
 ]
+"src/documenteer/ext/*" = [
+    # Sphinx role functions must match the docutils/Sphinx role API
+    # signature, (name, rawtext, text, lineno, inliner, options, content),
+    # and Sphinx calls them positionally, so these parameters cannot be made
+    # keyword-only.
+    "PLR0917", # role signatures are dictated by the Sphinx role API
+]
 "tests/**" = [
     "D103",    # tests don't need docstrings
     "PLR0915", # tests are allowed to be long, sometimes that's convenient


### PR DESCRIPTION
## Background

Ruff 0.16.0 stabilized `PLR0917` (`too-many-positional-arguments`), which had
previously been a preview-only rule. Because `ruff-shared.toml` selects `ALL`
and does not list `PLR0917` among its ignores, the rule becomes active for this
repo the moment the pinned ruff crosses 0.16.0 — surfacing 7 new errors that a
routine pre-commit autoupdate would turn into a red CI run.

Verified against ruff 0.16.0 specifically (the pinned `ruff-pre-commit` rev is
still `v0.15.20`, which does not report the rule):

```
$ uvx ruff@0.16.0 check --select PLR0917,ISC004 .
src/documenteer/ext/jira.py:65:5:            PLR0917 Too many positional arguments (7 > 5)
src/documenteer/ext/jira.py:104:5:           PLR0917 Too many positional arguments (9 > 5)
src/documenteer/ext/jira.py:139:5:           PLR0917 Too many positional arguments (7 > 5)
src/documenteer/ext/lsstdocushare.py:20:5:   PLR0917 Too many positional arguments (7 > 5)
src/documenteer/ext/lsstdocushare.py:46:5:   PLR0917 Too many positional arguments (7 > 5)
src/documenteer/ext/lsstdocushare.py:72:5:   PLR0917 Too many positional arguments (7 > 5)
src/documenteer/ext/mockcoderefs.py:24:5:    PLR0917 Too many positional arguments (7 > 5)
Found 7 errors.
```

`ISC004` reported nothing in this repo, before or after.

## Why a scoped ignore rather than a code fix

All 7 findings are Sphinx role functions. Their signature is not ours to
choose — docutils and Sphinx define the role calling convention as

```
(name, rawtext, text, lineno, inliner, options, content)
```

and Sphinx invokes registered roles **positionally**. Marking any of those
parameters keyword-only (the fix `PLR0917` wants) would raise `TypeError` at
documentation-build time for every project using `:jira:`, `:jirab:`,
`:jirap:`, the `:sqr:`/`:dmtn:`/etc. shortlinks, `:lsst-doc:`, and the mock
`:lmod:`/`:lclass:`/`:lfunc:` roles. The rule is measuring a real property
here, but the property is imposed by an external API, so the correct
disposition is to exempt the directory rather than to "fix" the code.

The ignore is deliberately narrow — `src/documenteer/ext/*`, the only place
role functions live — so `PLR0917` keeps its teeth everywhere else in the
package.

## Changes

One entry added to `[tool.ruff.lint.extend-per-file-ignores]` in
`pyproject.toml`, matching the style of the existing entries, with a comment
recording the rationale:

```toml
"src/documenteer/ext/*" = [
    # Sphinx role functions must match the docutils/Sphinx role API
    # signature, (name, rawtext, text, lineno, inliner, options, content),
    # and Sphinx calls them positionally, so these parameters cannot be made
    # keyword-only.
    "PLR0917", # role signatures are dictated by the Sphinx role API
]
```

No Python source was touched. `ruff-shared.toml` is deliberately **not**
modified — it is a vendored copy of the shared SQuaRE config and must keep
matching its upstream source.

## Validation

- `uvx ruff@0.16.0 check --select PLR0917,ISC004 .` — 7 errors before,
  **`All checks passed!`** after
- `uvx ruff@0.15.20 check .` (the currently pinned version) — clean; the new
  key is accepted, not just ignored
- `uvx ruff@0.15.20 format --check .` — 92 files already formatted
- `nox -s typing test` — 18/18 sessions green (Python 3.12/3.13/3.14 ×
  Sphinx 8/9/dev; 181 tests per test session)

No changelog fragment: this is lint configuration only, with no user-visible
behavior change.
