### PR TITLE
DM-55493: drop split-on-trailing-comma redundant with ruff-shared.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -263,7 +263,6 @@ extend-ignore = [
 
 [tool.ruff.lint.isort]
 known-first-party = ["documenteer", "tests"]
-split-on-trailing-comma = false
 
 [tool.ruff.lint.pep8-naming]
 classmethod-decorators = [


### PR DESCRIPTION
`ruff-shared.toml` already sets `[lint.isort] split-on-trailing-comma = false`, so the copy in `pyproject.toml` is dead config — removing it is behaviourally inert.

This clears the `toml-not-redundant` check of the `ruff-shared-config` migration, which is the last thing keeping documenteer non-compliant after the ruff 0.16.0 CPY001 refresh (#353) and the Sphinx role scoping (#356).

**Why this is a separate PR:** it was meant to ride along with #356, but that PR merged about a minute before this change was pushed, so the commit landed on an already-merged branch and never reached main.

## Validation
- `ruff 0.16.0 check .` — All checks passed
- `ruff 0.16.0 format --check .` — 139 files already formatted
- Diff is a single deletion; no behaviour change, since the inherited value is identical.

Ref: DM-55493