### PR TITLE
DM-55688: Move dependabot to monthly grouped updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,18 +3,35 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "thursday"
-      time: "09:00"
-      timezone: America/Toronto
+      interval: "monthly"
+      time: "03:00"
+      timezone: "America/New_York"
     reviewers:
       - "jonathansick"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
   - package-ecosystem: "pip"
     directory: "/"
+    versioning-strategy: "increase-if-necessary"
     schedule:
-      interval: "weekly"
-      day: "thursday"
-      time: "09:00"
-      timezone: America/Toronto
+      interval: "monthly"
+      time: "03:00"
+      timezone: "America/New_York"
     reviewers:
       - "jonathansick"
+    groups:
+      pip:
+        patterns:
+          - "*"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      time: "03:00"
+      timezone: "America/New_York"
+    groups:
+      npm:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Move all dependabot updates to a monthly schedule (03:00 America/New_York), dropping the weekly `day:` key.
- Add wildcard groups to the existing `github-actions` and `pip` entries so each ecosystem's updates batch into one PR.
- Add `versioning-strategy: "increase-if-necessary"` to the `pip` entry so dependabot doesn't raise lower bounds unnecessarily on ranges like `documenteer[technote]>1,<2`.
- Add a new `npm` entry (root `package-lock.json` exists) with a monthly schedule and wildcard group.
- No `docker` entry added — no root Dockerfile.

Jira: DM-55688

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"` exits 0
- [x] No `interval: weekly` / `interval: daily` remain
- [x] Every `updates:` entry has a `groups:` key